### PR TITLE
[DO NOT MERGE] Add import option from merging pki-init into security-secrets-setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,10 +18,10 @@ cmd/core-data/core-data
 cmd/core-metadata/core-metadata
 cmd/export-client/export-client
 cmd/export-distro/export-distro
-cmd/security-secrets-setup/security-secrets-setup
-cmd/security-secrets-setup/config/*
-cmd/security-secretstore-setup/security-secretstore-setup
 cmd/security-proxy-setup/security-proxy-setup
+cmd/security-secrets-setup/config/*
+cmd/security-secrets-setup/security-secrets-setup
+cmd/security-secretstore-setup/security-secretstore-setup
 cmd/support-logging/support-logging
 cmd/support-notifications/support-notifications
 cmd/support-scheduler/support-scheduler

--- a/cmd/config-seed/Attribution.txt
+++ b/cmd/config-seed/Attribution.txt
@@ -140,3 +140,9 @@ https://github.com/golang/net/blob/master/LICENSE
 
 gopkg.in/yaml.v2 (Apache 2.0) https://github.com/go-yaml/yaml/
 https://github.com/go-yaml/yaml/blob/v2.2.2/LICENSE
+
+fsnotify/fsnotify (BSD-3) https://github.com/fsnotify/fsnotify
+https://github.com/fsnotify/fsnotify/blob/master/LICENSE
+
+golang.org/x/sys (Unspecified) https://github.com/golang/sys
+https://github.com/golang/sys/blob/master/LICENSE

--- a/cmd/core-command/Attribution.txt
+++ b/cmd/core-command/Attribution.txt
@@ -140,3 +140,9 @@ https://github.com/golang/net/blob/master/LICENSE
 
 gopkg.in/yaml.v2 (Apache 2.0) https://github.com/go-yaml/yaml/
 https://github.com/go-yaml/yaml/blob/v2.2.2/LICENSE
+
+fsnotify/fsnotify (BSD-3) https://github.com/fsnotify/fsnotify
+https://github.com/fsnotify/fsnotify/blob/master/LICENSE
+
+golang.org/x/sys (Unspecified) https://github.com/golang/sys
+https://github.com/golang/sys/blob/master/LICENSE

--- a/cmd/core-data/Attribution.txt
+++ b/cmd/core-data/Attribution.txt
@@ -140,3 +140,9 @@ https://github.com/golang/net/blob/master/LICENSE
 
 gopkg.in/yaml.v2 (Apache 2.0) https://github.com/go-yaml/yaml/
 https://github.com/go-yaml/yaml/blob/v2.2.2/LICENSE
+
+fsnotify/fsnotify (BSD-3) https://github.com/fsnotify/fsnotify
+https://github.com/fsnotify/fsnotify/blob/master/LICENSE
+
+golang.org/x/sys (Unspecified) https://github.com/golang/sys
+https://github.com/golang/sys/blob/master/LICENSE

--- a/cmd/core-metadata/Attribution.txt
+++ b/cmd/core-metadata/Attribution.txt
@@ -140,3 +140,9 @@ https://github.com/golang/net/blob/master/LICENSE
 
 gopkg.in/yaml.v2 (Apache 2.0) https://github.com/go-yaml/yaml/
 https://github.com/go-yaml/yaml/blob/v2.2.2/LICENSE
+
+fsnotify/fsnotify (BSD-3) https://github.com/fsnotify/fsnotify
+https://github.com/fsnotify/fsnotify/blob/master/LICENSE
+
+golang.org/x/sys (Unspecified) https://github.com/golang/sys
+https://github.com/golang/sys/blob/master/LICENSE

--- a/cmd/export-client/Attribution.txt
+++ b/cmd/export-client/Attribution.txt
@@ -140,3 +140,9 @@ https://github.com/golang/net/blob/master/LICENSE
 
 gopkg.in/yaml.v2 (Apache 2.0) https://github.com/go-yaml/yaml/
 https://github.com/go-yaml/yaml/blob/v2.2.2/LICENSE
+
+fsnotify/fsnotify (BSD-3) https://github.com/fsnotify/fsnotify
+https://github.com/fsnotify/fsnotify/blob/master/LICENSE
+
+golang.org/x/sys (Unspecified) https://github.com/golang/sys
+https://github.com/golang/sys/blob/master/LICENSE

--- a/cmd/export-distro/Attribution.txt
+++ b/cmd/export-distro/Attribution.txt
@@ -140,3 +140,9 @@ https://github.com/golang/net/blob/master/LICENSE
 
 gopkg.in/yaml.v2 (Apache 2.0) https://github.com/go-yaml/yaml/
 https://github.com/go-yaml/yaml/blob/v2.2.2/LICENSE
+
+fsnotify/fsnotify (BSD-3) https://github.com/fsnotify/fsnotify
+https://github.com/fsnotify/fsnotify/blob/master/LICENSE
+
+golang.org/x/sys (Unspecified) https://github.com/golang/sys
+https://github.com/golang/sys/blob/master/LICENSE

--- a/cmd/security-proxy-setup/Attribution.txt
+++ b/cmd/security-proxy-setup/Attribution.txt
@@ -140,3 +140,9 @@ https://github.com/golang/net/blob/master/LICENSE
 
 gopkg.in/yaml.v2 (Apache 2.0) https://github.com/go-yaml/yaml/
 https://github.com/go-yaml/yaml/blob/v2.2.2/LICENSE
+
+fsnotify/fsnotify (BSD-3) https://github.com/fsnotify/fsnotify
+https://github.com/fsnotify/fsnotify/blob/master/LICENSE
+
+golang.org/x/sys (Unspecified) https://github.com/golang/sys
+https://github.com/golang/sys/blob/master/LICENSE

--- a/cmd/security-secrets-setup/Attribution.txt
+++ b/cmd/security-secrets-setup/Attribution.txt
@@ -140,3 +140,9 @@ https://github.com/golang/net/blob/master/LICENSE
 
 gopkg.in/yaml.v2 (Apache 2.0) https://github.com/go-yaml/yaml/
 https://github.com/go-yaml/yaml/blob/v2.2.2/LICENSE
+
+fsnotify/fsnotify (BSD-3) https://github.com/fsnotify/fsnotify
+https://github.com/fsnotify/fsnotify/blob/master/LICENSE
+
+golang.org/x/sys (Unspecified) https://github.com/golang/sys
+https://github.com/golang/sys/blob/master/LICENSE

--- a/cmd/security-secrets-setup/main.go
+++ b/cmd/security-secrets-setup/main.go
@@ -45,6 +45,7 @@ var dispatcherInstance = newOptionDispatcher()
 var subcommands = map[string]*flag.FlagSet{
 	"legacy":   flag.NewFlagSet("legacy", flag.ExitOnError),
 	"generate": flag.NewFlagSet("generate", flag.ExitOnError),
+	"cache":    flag.NewFlagSet("cache", flag.ExitOnError),
 }
 var configFile string
 
@@ -107,7 +108,7 @@ func main() {
 			return
 		}
 
-	case "generate":
+	case "generate", "cache":
 		// no arguments expected
 		if len(subcmd.Args()) > 0 {
 			setup.LoggingClient.Error(fmt.Sprintf("subcommand %s doesn't use any args", subcmdName))
@@ -137,14 +138,17 @@ func newOptionDispatcher() optionDispatcher {
 }
 
 func setupPkiInitOption(subcommand string) (executor option.OptionsExecutor, status int, err error) {
-	generateOpt := false
+	var generateOpt, cacheOpt bool
 	switch subcommand {
 	case "generate":
 		generateOpt = true
+	case "cache":
+		cacheOpt = true
 	}
 
 	opts := option.PkiInitOption{
 		GenerateOpt: generateOpt,
+		CacheOpt:    cacheOpt,
 	}
 	return option.NewPkiInitOption(opts)
 }

--- a/cmd/security-secrets-setup/main.go
+++ b/cmd/security-secrets-setup/main.go
@@ -46,6 +46,7 @@ var subcommands = map[string]*flag.FlagSet{
 	"legacy":   flag.NewFlagSet("legacy", flag.ExitOnError),
 	"generate": flag.NewFlagSet("generate", flag.ExitOnError),
 	"cache":    flag.NewFlagSet("cache", flag.ExitOnError),
+	"import":   flag.NewFlagSet("import", flag.ExitOnError),
 }
 var configFile string
 
@@ -108,7 +109,7 @@ func main() {
 			return
 		}
 
-	case "generate", "cache":
+	case "generate", "cache", "import":
 		// no arguments expected
 		if len(subcmd.Args()) > 0 {
 			setup.LoggingClient.Error(fmt.Sprintf("subcommand %s doesn't use any args", subcmdName))
@@ -138,17 +139,20 @@ func newOptionDispatcher() optionDispatcher {
 }
 
 func setupPkiInitOption(subcommand string) (executor option.OptionsExecutor, status int, err error) {
-	var generateOpt, cacheOpt bool
+	var generateOpt, cacheOpt, importOpt bool
 	switch subcommand {
 	case "generate":
 		generateOpt = true
 	case "cache":
 		cacheOpt = true
+	case "import":
+		importOpt = true
 	}
 
 	opts := option.PkiInitOption{
 		GenerateOpt: generateOpt,
 		CacheOpt:    cacheOpt,
+		ImportOpt:   importOpt,
 	}
 	return option.NewPkiInitOption(opts)
 }

--- a/cmd/security-secrets-setup/main_test.go
+++ b/cmd/security-secrets-setup/main_test.go
@@ -160,6 +160,20 @@ func TestMainWithCacheOption(t *testing.T) {
 	assert.Equal(false, (optionExec.(*option.PkiInitOption)).GenerateOpt)
 }
 
+func TestMainWithImportOption(t *testing.T) {
+	tearDown := setupTest(t)
+	origArgs := os.Args
+	defer tearDown(t, origArgs)
+	assert := assert.New(t)
+
+	runWithImportOption(false)
+	assert.Equal(0, (exitInstance.(*testExitCode)).getStatusCode())
+	optionExec := (dispatcherInstance.(*testPkiInitOptionDispatcher)).testOptsExecutor
+	assert.Equal(true, (optionExec.(*option.PkiInitOption)).ImportOpt)
+	assert.Equal(false, (optionExec.(*option.PkiInitOption)).CacheOpt)
+	assert.Equal(false, (optionExec.(*option.PkiInitOption)).GenerateOpt)
+}
+
 func runWithGenerateOption(hasError bool) {
 	os.Args = []string{"cmd", "generate"}
 	printCommandLineStrings(os.Args)
@@ -169,6 +183,13 @@ func runWithGenerateOption(hasError bool) {
 
 func runWithCacheOption(hasError bool) {
 	os.Args = []string{"cmd", "cache"}
+	printCommandLineStrings(os.Args)
+	hasDispatchError = hasError
+	main()
+}
+
+func runWithImportOption(hasError bool) {
+	os.Args = []string{"cmd", "import"}
 	printCommandLineStrings(os.Args)
 	hasDispatchError = hasError
 	main()
@@ -222,12 +243,14 @@ func (testDispatcher *testPkiInitOptionDispatcher) run(command string) (statusCo
 
 	genOpt := false
 	cacheOpt := false
+	importOpt := false
 	if pkiInit, ok := optsExecutor.(*option.PkiInitOption); ok {
 		genOpt = pkiInit.GenerateOpt
 		cacheOpt = pkiInit.CacheOpt
+		importOpt = pkiInit.ImportOpt
 	}
 
-	fmt.Printf("In test flag value: generateOpt = %v, cacheOpt = %v, configFile = %v\n", genOpt, cacheOpt, configFile)
+	fmt.Printf("In test flag value: generateOpt = %v, cacheOpt = %v, importOpt = %v, configFile = %v\n", genOpt, cacheOpt, importOpt, configFile)
 
 	testDispatcher.testOptsExecutor = optsExecutor
 

--- a/cmd/security-secretstore-setup/Attribution.txt
+++ b/cmd/security-secretstore-setup/Attribution.txt
@@ -140,3 +140,9 @@ https://github.com/golang/net/blob/master/LICENSE
 
 gopkg.in/yaml.v2 (Apache 2.0) https://github.com/go-yaml/yaml/
 https://github.com/go-yaml/yaml/blob/v2.2.2/LICENSE
+
+fsnotify/fsnotify (BSD-3) https://github.com/fsnotify/fsnotify
+https://github.com/fsnotify/fsnotify/blob/master/LICENSE
+
+golang.org/x/sys (Unspecified) https://github.com/golang/sys
+https://github.com/golang/sys/blob/master/LICENSE

--- a/cmd/support-logging/Attribution.txt
+++ b/cmd/support-logging/Attribution.txt
@@ -140,3 +140,9 @@ https://github.com/golang/net/blob/master/LICENSE
 
 gopkg.in/yaml.v2 (Apache 2.0) https://github.com/go-yaml/yaml/
 https://github.com/go-yaml/yaml/blob/v2.2.2/LICENSE
+
+fsnotify/fsnotify (BSD-3) https://github.com/fsnotify/fsnotify
+https://github.com/fsnotify/fsnotify/blob/master/LICENSE
+
+golang.org/x/sys (Unspecified) https://github.com/golang/sys
+https://github.com/golang/sys/blob/master/LICENSE

--- a/cmd/support-notifications/Attribution.txt
+++ b/cmd/support-notifications/Attribution.txt
@@ -140,3 +140,9 @@ https://github.com/golang/net/blob/master/LICENSE
 
 gopkg.in/yaml.v2 (Apache 2.0) https://github.com/go-yaml/yaml/
 https://github.com/go-yaml/yaml/blob/v2.2.2/LICENSE
+
+fsnotify/fsnotify (BSD-3) https://github.com/fsnotify/fsnotify
+https://github.com/fsnotify/fsnotify/blob/master/LICENSE
+
+golang.org/x/sys (Unspecified) https://github.com/golang/sys
+https://github.com/golang/sys/blob/master/LICENSE

--- a/cmd/support-scheduler/Attribution.txt
+++ b/cmd/support-scheduler/Attribution.txt
@@ -140,3 +140,9 @@ https://github.com/golang/net/blob/master/LICENSE
 
 gopkg.in/yaml.v2 (Apache 2.0) https://github.com/go-yaml/yaml/
 https://github.com/go-yaml/yaml/blob/v2.2.2/LICENSE
+
+fsnotify/fsnotify (BSD-3) https://github.com/fsnotify/fsnotify
+https://github.com/fsnotify/fsnotify/blob/master/LICENSE
+
+golang.org/x/sys (Unspecified) https://github.com/golang/sys
+https://github.com/golang/sys/blob/master/LICENSE

--- a/cmd/sys-mgmt-agent/Attribution.txt
+++ b/cmd/sys-mgmt-agent/Attribution.txt
@@ -140,3 +140,9 @@ https://github.com/golang/net/blob/master/LICENSE
 
 gopkg.in/yaml.v2 (Apache 2.0) https://github.com/go-yaml/yaml/
 https://github.com/go-yaml/yaml/blob/v2.2.2/LICENSE
+
+fsnotify/fsnotify (BSD-3) https://github.com/fsnotify/fsnotify
+https://github.com/fsnotify/fsnotify/blob/master/LICENSE
+
+golang.org/x/sys (Unspecified) https://github.com/golang/sys
+https://github.com/golang/sys/blob/master/LICENSE

--- a/cmd/sys-mgmt-executor/Attribution.txt
+++ b/cmd/sys-mgmt-executor/Attribution.txt
@@ -140,3 +140,9 @@ https://github.com/golang/net/blob/master/LICENSE
 
 gopkg.in/yaml.v2 (Apache 2.0) https://github.com/go-yaml/yaml/
 https://github.com/go-yaml/yaml/blob/v2.2.2/LICENSE
+
+fsnotify/fsnotify (BSD-3) https://github.com/fsnotify/fsnotify
+https://github.com/fsnotify/fsnotify/blob/master/LICENSE
+
+golang.org/x/sys (Unspecified) https://github.com/golang/sys
+https://github.com/golang/sys/blob/master/LICENSE

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/edgexfoundry/go-mod-core-contracts v0.1.25
 	github.com/edgexfoundry/go-mod-messaging v0.1.9
 	github.com/edgexfoundry/go-mod-registry v0.1.12
+	github.com/fsnotify/fsnotify v1.4.7
 	github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8
 	github.com/go-kit/kit v0.8.0
 	github.com/gomodule/redigo v2.0.0+incompatible

--- a/internal/core/metadata/config.go
+++ b/internal/core/metadata/config.go
@@ -14,6 +14,7 @@
 package metadata
 
 import (
+	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/interfaces"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/config"
 )
 
@@ -31,4 +32,58 @@ type ConfigurationStruct struct {
 type WritableInfo struct {
 	LogLevel                        string
 	EnableValueDescriptorManagement bool
+}
+
+// UpdateFromRaw converts configuration received from the registry to a service-specific configuration struct which is
+// then used to overwrite the service's existing configuration struct.
+func (c *ConfigurationStruct) UpdateFromRaw(rawConfig interface{}) bool {
+	configuration, ok := rawConfig.(*ConfigurationStruct)
+	if ok {
+		// Check that information was successfully read from Registry
+		if configuration.Service.Port == 0 {
+			return false
+		}
+		c = configuration
+	}
+	return ok
+}
+
+// EmptyWritablePtr returns a pointer to a service-specific empty WritableInfo struct.  It is used by the bootstrap to
+// provide the appropriate structure to registry.Client's WatchForChanges().
+func (c *ConfigurationStruct) EmptyWritablePtr() interface{} {
+	return &WritableInfo{}
+}
+
+// UpdateWritableFromRaw converts configuration received from the registry to a service-specific WritableInfo struct
+// which is then used to overwrite the service's existing configuration's WritableInfo struct.
+func (c *ConfigurationStruct) UpdateWritableFromRaw(rawWritable interface{}) bool {
+	writable, ok := rawWritable.(*WritableInfo)
+	if ok {
+		c.Writable = *writable
+	}
+	return ok
+}
+
+// GetBootstrap returns the configuration elements required by the bootstrap.  Currently, a copy of the configuration
+// data is returned.  This is intended to be temporary -- since ConfigurationStruct drives the configuration.toml's
+// structure -- until we can make backwards-breaking configuration.toml changes (which would consolidate these fields
+// into an interfaces.BootstrapConfiguration struct contained within ConfigurationStruct).
+func (c *ConfigurationStruct) GetBootstrap() interfaces.BootstrapConfiguration {
+	// temporary until we can make backwards-breaking configuration.toml change
+	return interfaces.BootstrapConfiguration{
+		Clients:  c.Clients,
+		Service:  c.Service,
+		Registry: c.Registry,
+		Logging:  c.Logging,
+	}
+}
+
+// GetLogLevel returns the current ConfigurationStruct's log level.
+func (c *ConfigurationStruct) GetLogLevel() string {
+	return c.Writable.LogLevel
+}
+
+// SetLogLevel updates the log level in the ConfigurationStruct.
+func (c *ConfigurationStruct) SetRegistryInfo(registryInfo config.RegistryInfo) {
+	c.Registry = registryInfo
 }

--- a/internal/core/metadata/init.go
+++ b/internal/core/metadata/init.go
@@ -15,226 +15,71 @@
 package metadata
 
 import (
-	"errors"
+	"context"
 	"fmt"
-	"os"
-	"os/signal"
 	"sync"
-	"syscall"
 	"time"
 
-	"github.com/edgexfoundry/edgex-go/internal"
 	"github.com/edgexfoundry/edgex-go/internal/core/metadata/interfaces"
-	"github.com/edgexfoundry/edgex-go/internal/pkg/config"
+	bootstrap "github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/interfaces"
+	"github.com/edgexfoundry/edgex-go/internal/pkg/bootstrap/startup"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/db"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/db/mongo"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/db/redis"
 	"github.com/edgexfoundry/edgex-go/internal/pkg/endpoint"
-	"github.com/edgexfoundry/edgex-go/internal/pkg/telemetry"
-
 	"github.com/edgexfoundry/go-mod-core-contracts/clients"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/coredata"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/notifications"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/types"
 
-	registryTypes "github.com/edgexfoundry/go-mod-registry/pkg/types"
 	"github.com/edgexfoundry/go-mod-registry/registry"
 )
 
 // Global variables
-var Configuration *ConfigurationStruct
+var Configuration = &ConfigurationStruct{}
 var dbClient interfaces.DBClient
 var LoggingClient logger.LoggingClient
-var registryClient registry.Client
 var nc notifications.NotificationsClient
 var vdc coredata.ValueDescriptorClient
-var registryErrors chan error        //A channel for "config wait errors" sourced from Registry
-var registryUpdates chan interface{} //A channel for "config updates" sourced from Registry.
 
-func Retry(useRegistry bool, configDir, profileDir string, timeout int, wait *sync.WaitGroup, ch chan error) {
-	until := time.Now().Add(time.Millisecond * time.Duration(timeout))
-	for time.Now().Before(until) {
-		var err error
-		//When looping, only handle configuration if it hasn't already been set.
-		if Configuration == nil {
-			Configuration, err = initializeConfiguration(useRegistry, configDir, profileDir)
-			if err != nil {
-				ch <- err
-				if !useRegistry {
-					//Error occurred when attempting to read from local filesystem. Fail fast.
-					close(ch)
-					wait.Done()
-					return
-				}
-			} else {
-				// Initialize notificationsClient based on configuration
-				initializeClients(useRegistry)
-				// Setup Logging
-				logTarget := setLoggingTarget()
-				LoggingClient = logger.NewClient(clients.CoreMetaDataServiceKey, Configuration.Logging.EnableRemote, logTarget, Configuration.Writable.LogLevel)
-			}
-		}
-
-		//Only attempt to connect to database if configuration has been populated
-		if Configuration != nil {
-			err := connectToDatabase()
-			if err != nil {
-				ch <- err
-			} else {
-				break
-			}
-		}
-		time.Sleep(time.Second * time.Duration(1))
-	}
-	close(ch)
-	wait.Done()
-
-	return
+type server interface {
+	IsRunning() bool
 }
 
-func Init(useRegistry bool) bool {
-	if Configuration == nil || dbClient == nil {
-		return false
-	}
-	if useRegistry {
-		registryErrors = make(chan error)
-		registryUpdates = make(chan interface{})
-		go listenForConfigChanges()
-	}
-
-	go telemetry.StartCpuUsageAverage()
-
-	return true
+type ServiceInit struct {
+	server server
 }
 
-func Destruct() {
-	if dbClient != nil {
-		dbClient.CloseSession()
-		dbClient = nil
+func NewServiceInit(server server) ServiceInit {
+	return ServiceInit{
+		server: server,
 	}
 }
 
-func initializeConfiguration(useRegistry bool, configDir, profileDir string) (*ConfigurationStruct, error) {
-	//We currently have to load configuration from filesystem first in order to obtain RegistryHost/Port
-	configuration := &ConfigurationStruct{}
-	err := config.LoadFromFile(configDir, profileDir, configuration)
-	if err != nil {
-		return nil, err
+func (s ServiceInit) initializeClients(useRegistry bool, registryClient registry.Client) {
+	// Create notification client
+	nParams := types.EndpointParams{
+		ServiceKey:  clients.SupportNotificationsServiceKey,
+		Path:        clients.ApiNotificationRoute,
+		UseRegistry: useRegistry,
+		Url:         Configuration.Clients["Notifications"].Url() + clients.ApiNotificationRoute,
+		Interval:    Configuration.Service.ClientMonitor,
 	}
-	configuration.Registry = config.OverrideFromEnvironment(configuration.Registry)
+	nc = notifications.NewNotificationsClient(nParams, endpoint.Endpoint{RegistryClient: &registryClient})
 
-	if useRegistry {
-		err = connectToRegistry(configuration)
-		if err != nil {
-			return nil, err
-		}
-
-		rawConfig, err := registryClient.GetConfiguration(configuration)
-		if err != nil {
-			return nil, fmt.Errorf("could not get configuration from Registry: %v", err.Error())
-		}
-
-		actual, ok := rawConfig.(*ConfigurationStruct)
-		if !ok {
-			return nil, fmt.Errorf("configuration from Registry failed type check")
-		}
-
-		configuration = actual
-
-		// Check that information was successfully read from Registry
-		if configuration.Service.Port == 0 {
-			return nil, errors.New("error reading configuration from Registry")
-		}
+	vParams := types.EndpointParams{
+		ServiceKey:  clients.CoreDataServiceKey,
+		Path:        clients.ApiValueDescriptorRoute,
+		UseRegistry: useRegistry,
+		Url:         Configuration.Clients["CoreData"].Url() + clients.ApiValueDescriptorRoute,
+		Interval:    Configuration.Service.ClientMonitor,
 	}
-	return configuration, nil
-}
-
-func connectToRegistry(conf *ConfigurationStruct) error {
-	var err error
-	registryConfig := registryTypes.Config{
-		Host:            conf.Registry.Host,
-		Port:            conf.Registry.Port,
-		Type:            conf.Registry.Type,
-		ServiceKey:      clients.CoreMetaDataServiceKey,
-		ServiceHost:     conf.Service.Host,
-		ServicePort:     conf.Service.Port,
-		ServiceProtocol: conf.Service.Protocol,
-		CheckInterval:   conf.Service.CheckInterval,
-		CheckRoute:      clients.ApiPingRoute,
-		Stem:            internal.ConfigRegistryStemCore + internal.ConfigMajorVersion,
-	}
-
-	registryClient, err = registry.NewRegistryClient(registryConfig)
-	if err != nil {
-		return fmt.Errorf("connection to Registry could not be made: %v", err.Error())
-	}
-
-	// Check if registry service is running
-	if !registryClient.IsAlive() {
-		return fmt.Errorf("registry is not available")
-	}
-
-	// Register the service with Registry
-	err = registryClient.Register()
-	if err != nil {
-		return fmt.Errorf("could not register service with Registry: %v", err.Error())
-	}
-
-	return nil
-}
-
-func listenForConfigChanges() {
-	if registryClient == nil {
-		LoggingClient.Error("listenForConfigChanges() registry client not set")
-		return
-	}
-
-	registryClient.WatchForChanges(registryUpdates, registryErrors, &WritableInfo{}, internal.WritableKey)
-
-	signals := make(chan os.Signal)
-	signal.Notify(signals, os.Interrupt, syscall.SIGTERM)
-
-	for {
-		select {
-		case <-signals:
-			// Quietly and gracefully stop when SIGINT/SIGTERM received
-			return
-
-		case ex := <-registryErrors:
-			LoggingClient.Error(ex.Error())
-		case raw, ok := <-registryUpdates:
-			if ok {
-				actual, ok := raw.(*WritableInfo)
-				if !ok {
-					LoggingClient.Error("listenForConfigChanges() type check failed")
-				}
-
-				Configuration.Writable = *actual
-
-				LoggingClient.Info("Writeable configuration has been updated from the Registry")
-				LoggingClient.SetLogLevel(Configuration.Writable.LogLevel)
-			} else {
-				return
-			}
-		}
-	}
-}
-
-func connectToDatabase() error {
-	var err error
-
-	dbClient, err = newDBClient(Configuration.Databases["Primary"].Type)
-	if err != nil {
-		dbClient = nil
-		return fmt.Errorf("couldn't create database client: %v", err.Error())
-	}
-
-	return nil
+	vdc = coredata.NewValueDescriptorClient(vParams, endpoint.Endpoint{RegistryClient: &registryClient})
 }
 
 // Return the dbClient interface
-func newDBClient(dbType string) (interfaces.DBClient, error) {
+func (s ServiceInit) newDBClient(dbType string) (interfaces.DBClient, error) {
 	switch dbType {
 	case db.MongoDB:
 		dbConfig := db.Configuration{
@@ -251,37 +96,62 @@ func newDBClient(dbType string) (interfaces.DBClient, error) {
 			Host: Configuration.Databases["Primary"].Host,
 			Port: Configuration.Databases["Primary"].Port,
 		}
-		return redis.NewClient(dbConfig, LoggingClient) //TODO: Verify this also connects to Redis
+		redisClient, err := redis.NewCoreDataClient(dbConfig, LoggingClient) // TODO: Verify this also connects to Redis
+		if err != nil {
+			return nil, err
+		}
+
+		return redisClient, nil
 	default:
 		return nil, db.ErrUnsupportedDatabase
 	}
 }
 
-func initializeClients(useRegistry bool) {
-	// Create notification client
-	nParams := types.EndpointParams{
-		ServiceKey:  clients.SupportNotificationsServiceKey,
-		Path:        clients.ApiNotificationRoute,
-		UseRegistry: useRegistry,
-		Url:         Configuration.Clients["Notifications"].Url() + clients.ApiNotificationRoute,
-		Interval:    Configuration.Service.ClientMonitor,
+func (s ServiceInit) BootstrapHandler(
+	wg *sync.WaitGroup,
+	ctx context.Context,
+	startupTimer startup.Timer,
+	config bootstrap.Configuration,
+	logging logger.LoggingClient,
+	registry registry.Client) bool {
+
+	// update global variables.
+	LoggingClient = logging
+
+	// initialize clients required by service.
+	s.initializeClients(registry != nil, registry)
+
+	// initialize database.
+	for startupTimer.HasNotElapsed() {
+		var err error
+		dbClient, err = s.newDBClient(Configuration.Databases["Primary"].Type)
+		if err == nil {
+			break
+		}
+		LoggingClient.Warn(fmt.Sprintf("couldn't create database client: %v", err.Error()))
+		startupTimer.SleepForInterval()
 	}
 
-	nc = notifications.NewNotificationsClient(nParams, endpoint.Endpoint{RegistryClient: &registryClient})
-
-	vParams := types.EndpointParams{
-		ServiceKey:  clients.CoreDataServiceKey,
-		Path:        clients.ApiValueDescriptorRoute,
-		UseRegistry: useRegistry,
-		Url:         Configuration.Clients["CoreData"].Url() + clients.ApiValueDescriptorRoute,
-		Interval:    Configuration.Service.ClientMonitor,
+	if dbClient == nil {
+		return false
 	}
-	vdc = coredata.NewValueDescriptorClient(vParams, endpoint.Endpoint{RegistryClient: &registryClient})
-}
 
-func setLoggingTarget() string {
-	if Configuration.Logging.EnableRemote {
-		return Configuration.Clients["Logging"].Url() + clients.ApiLoggingRoute
-	}
-	return Configuration.Logging.File
+	LoggingClient.Info("Database connected")
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		<-ctx.Done()
+		for {
+			// wait for httpServer to stop running (e.g. handling requests) before closing the database connection.
+			if s.server.IsRunning() == false {
+				dbClient.CloseSession()
+				break
+			}
+			time.Sleep(time.Second)
+		}
+		LoggingClient.Info("Database disconnected")
+	}()
+
+	return true
 }

--- a/internal/pkg/usage/usage.go
+++ b/internal/pkg/usage/usage.go
@@ -48,6 +48,7 @@ Server Options:
 
 Server Subcommand:	
 	generate                        Generate PKI afresh every time and deployed. Typically, this will be whenever the framework is started.
+	cache                           Generate PKI exactly once and then copied to a designated cache location for future use.  The PKI is then deployed from the cached location.
 	legacy                          [Will be deprecated] Legacy mode to generate PKI
 	  -c, --config <name>           Provide absolute path to JSON configuration file
 

--- a/internal/pkg/usage/usage.go
+++ b/internal/pkg/usage/usage.go
@@ -49,6 +49,7 @@ Server Options:
 Server Subcommand:	
 	generate                        Generate PKI afresh every time and deployed. Typically, this will be whenever the framework is started.
 	cache                           Generate PKI exactly once and then copied to a designated cache location for future use.  The PKI is then deployed from the cached location.
+	import                          Import PKI from cached location to deployed location.  If cached location is empty, import blocks until PKI shown up before deploying.
 	legacy                          [Will be deprecated] Legacy mode to generate PKI
 	  -c, --config <name>           Provide absolute path to JSON configuration file
 

--- a/internal/security/setup/option/cache.go
+++ b/internal/security/setup/option/cache.go
@@ -1,0 +1,95 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0'
+//
+
+package option
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/edgexfoundry/edgex-go/internal/security/setup"
+)
+
+// Cache generates PKI exactly once and cached to a designated location for future use.
+// The PKI is then deployed from the cached location.
+func Cache() func(*PkiInitOption) (exitCode, error) {
+	return func(pkiInitOpton *PkiInitOption) (exitCode, error) {
+
+		if isCacheNoOp(pkiInitOpton) {
+			return normal, nil
+		}
+
+		return cachePkis()
+	}
+}
+
+func isCacheNoOp(pkiInitOption *PkiInitOption) bool {
+	// nop: if the flag is missing or not on
+	return pkiInitOption == nil || !pkiInitOption.CacheOpt
+}
+
+func cachePkis() (statusCode exitCode, err error) {
+	// generate a new one if pkicache dir is empty
+	pkiCacheDir := getPkiCacheDirEnv()
+	if empty, err := isDirEmpty(pkiCacheDir); err != nil {
+		return exitWithError, err
+	} else if empty {
+		setup.LoggingClient.Info(fmt.Sprintf("cache dir %s is empty, generating PKI into it...", pkiCacheDir))
+		// perform generate func
+		statusCode, err = generatePkis()
+		if err != nil {
+			return statusCode, err
+		}
+
+		generatedDirPath := filepath.Join(os.Getenv(envXdgRuntimeDir), pkiInitGeneratedDir)
+
+		// always shreds CA private key before cache
+		caPrivateKeyFile := filepath.Join(generatedDirPath, caServiceName, tlsSecretFileName)
+		if err := secureEraseFile(caPrivateKeyFile); err != nil {
+			return exitWithError, err
+		}
+
+		if err = doCache(generatedDirPath); err != nil {
+			return exitWithError, err
+		}
+	} else {
+		// cache dir is not empty: output error message if CA private key is present
+		// when cache is given
+		cachedCAPrivateKeyFile := filepath.Join(pkiCacheDir, caServiceName, tlsSecretFileName)
+		if checkIfFileExists(cachedCAPrivateKeyFile) {
+			return exitWithError, errCacheNotChangeAfter
+		}
+		setup.LoggingClient.Info(fmt.Sprintf("cached TLS assets from dir %s is present, using cached PKI", pkiCacheDir))
+	}
+
+	// to deploy
+	// copy stuff into dest dir from pkiCache
+	err = deploy(pkiCacheDir, pkiInitDeployDir)
+	if err != nil {
+		return exitWithError, err
+	}
+
+	return normal, nil
+}
+
+func doCache(fromDir string) error {
+	// destination
+	pkiCacheDir := getPkiCacheDirEnv()
+
+	// to cache
+	return copyDir(fromDir, pkiCacheDir)
+}

--- a/internal/security/setup/option/cache_test.go
+++ b/internal/security/setup/option/cache_test.go
@@ -13,11 +13,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0'
 //
-
 package option
 
 import (
-	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -27,119 +25,107 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var testExecutor *mockOptionsExecutor
-var vaultJSONPkiSetupExist bool
-var kongJSONPkiSetupExist bool
-
-func TestGenerate(t *testing.T) {
+func TestCacheOn(t *testing.T) {
 	vaultJSONPkiSetupExist = true
 	kongJSONPkiSetupExist = true
-	tearDown := setupGenerateTest(t)
-	defer tearDown(t)
+	tearDown := setupCacheTest(t)
+	defer tearDown()
 
 	options := PkiInitOption{
-		GenerateOpt: true,
+		CacheOpt: true,
 	}
-	generateOn, _, _ := NewPkiInitOption(options)
-	generateOn.(*PkiInitOption).executor = testExecutor
+	cacheOn, _, _ := NewPkiInitOption(options)
+	cacheOn.setExecutor(testExecutor)
 
-	f := Generate()
-	exitCode, err := f(generateOn.(*PkiInitOption))
+	var exitStatus exitCode
+	var err error
+	f := Cache()
+	exitStatus, err = f(cacheOn.(*PkiInitOption))
+
+	cacheEmpty, emptyErr := isDirEmpty(getPkiCacheDirEnv())
 
 	assert := assert.New(t)
-	assert.Equal(normal, exitCode)
+	assert.Equal(normal, exitStatus)
 	assert.Nil(err)
-	generatedDirPath := filepath.Join(getXdgRuntimeDir(), pkiInitGeneratedDir)
+	assert.Nil(emptyErr)
+	assert.False(cacheEmpty)
+
+	generatedDirPath := filepath.Join(os.Getenv(envXdgRuntimeDir), pkiInitGeneratedDir)
 	caPrivateKeyFile := filepath.Join(generatedDirPath, caServiceName, tlsSecretFileName)
-	fileExists := checkIfFileExists(caPrivateKeyFile)
-	assert.False(fileExists, "CA private key are not removed!")
+	if _, checkErr := os.Stat(caPrivateKeyFile); checkErr == nil {
+		// means found the file caPrivateKeyFile
+		assert.Fail("CA private key are not removed!")
+	}
 
 	deployEmpty, emptyErr := isDirEmpty(pkiInitDeployDir)
 	assert.Nil(emptyErr)
 	assert.False(deployEmpty)
-
-	// check sentinel file is present when deploy is done
-	sentinel := filepath.Join(pkiInitDeployDir, caServiceName, pkiInitFilePerServiceComplete)
-	fileExists = checkIfFileExists(sentinel)
-	assert.True(fileExists, "sentinel file does not exist for CA service!")
-
-	sentinel = filepath.Join(pkiInitDeployDir, vaultServiceName, pkiInitFilePerServiceComplete)
-	fileExists = checkIfFileExists(sentinel)
-	assert.True(fileExists, "sentinel file does not exist for vault service!")
 }
 
-func TestGenerateWithVaultJSONPkiSetupMissing(t *testing.T) {
-	vaultJSONPkiSetupExist = false // this will lead to missing json
-	kongJSONPkiSetupExist = true
-	tearDown := setupGenerateTest(t)
-	defer tearDown(t)
-
-	options := PkiInitOption{
-		GenerateOpt: true,
-	}
-	generateOn, _, _ := NewPkiInitOption(options)
-	generateOn.(*PkiInitOption).executor = testExecutor
-
-	f := Generate()
-	exitCode, err := f(generateOn.(*PkiInitOption))
-
-	assert := assert.New(t)
-	assert.Equal(exitWithError, exitCode)
-	assert.NotNil(err)
-}
-
-func TestGenerateWithKongJSONPkiSetupMissing(t *testing.T) {
-	kongJSONPkiSetupExist = false // this will lead to missing json
-	vaultJSONPkiSetupExist = true
-	tearDown := setupGenerateTest(t)
-	defer tearDown(t)
-
-	options := PkiInitOption{
-		GenerateOpt: true,
-	}
-	generateOn, _, _ := NewPkiInitOption(options)
-	generateOn.(*PkiInitOption).executor = testExecutor
-
-	f := Generate()
-	exitCode, err := f(generateOn.(*PkiInitOption))
-
-	assert := assert.New(t)
-	assert.Equal(exitWithError, exitCode)
-	assert.NotNil(err)
-}
-
-func TestGenerateOff(t *testing.T) {
+func TestCacheDirNotEmpty(t *testing.T) {
 	vaultJSONPkiSetupExist = true
 	kongJSONPkiSetupExist = true
-	tearDown := setupGenerateTest(t)
-	defer tearDown(t)
+	tearDown := setupCacheTest(t)
+	defer tearDown()
 
 	options := PkiInitOption{
-		GenerateOpt: false,
+		CacheOpt: true,
 	}
-	generateOff, _, _ := NewPkiInitOption(options)
-	generateOff.(*PkiInitOption).executor = testExecutor
-	exitCode, err := generateOff.executeOptions(Generate())
+	cacheOn, _, _ := NewPkiInitOption(options)
+	cacheOn.setExecutor(testExecutor)
+
+	var exitStatus exitCode
+	var err error
+	f := Cache()
+	exitStatus, err = f(cacheOn.(*PkiInitOption))
+
+	cacheEmpty, emptyErr := isDirEmpty(getPkiCacheDirEnv())
+
+	assert := assert.New(t)
+	assert.Equal(normal, exitStatus)
+	assert.Nil(err)
+	assert.Nil(emptyErr)
+	assert.False(cacheEmpty)
+
+	generatedDirPath := filepath.Join(os.Getenv(envXdgRuntimeDir), pkiInitGeneratedDir)
+	// now we move the whole generated directory and leave the cache dir untouched
+	os.RemoveAll(generatedDirPath)
+
+	// call the cache option again:
+	exitStatus, err = f(cacheOn.(*PkiInitOption))
+
+	cacheEmpty, emptyErr = isDirEmpty(getPkiCacheDirEnv())
+
+	assert.Equal(normal, exitStatus)
+	assert.Nil(err)
+	assert.Nil(emptyErr)
+	assert.False(cacheEmpty)
+
+	deployEmpty, emptyErr := isDirEmpty(pkiInitDeployDir)
+	assert.Nil(emptyErr)
+	assert.False(deployEmpty)
+}
+
+func TestCacheOff(t *testing.T) {
+	vaultJSONPkiSetupExist = true
+	kongJSONPkiSetupExist = true
+	tearDown := setupCacheTest(t)
+	defer tearDown()
+
+	options := PkiInitOption{
+		CacheOpt: false,
+	}
+	cacheOff, _, _ := NewPkiInitOption(options)
+	cacheOff.setExecutor(testExecutor)
+	exitCode, err := cacheOff.executeOptions(Cache())
 
 	assert := assert.New(t)
 	assert.Equal(normal, exitCode)
 	assert.Nil(err)
 }
 
-func TestGetXdgRuntimeDir(t *testing.T) {
-	origEnvVal := os.Getenv(envXdgRuntimeDir)
-	os.Unsetenv(envXdgRuntimeDir)
-	runTimeDir := getXdgRuntimeDir()
-	assert.Equal(t, defaultXdgRuntimeDir, runTimeDir)
-
-	os.Setenv(envXdgRuntimeDir, origEnvVal)
-	runTimeDir = getXdgRuntimeDir()
-	assert.Equal(t, origEnvVal, runTimeDir)
-}
-
-func setupGenerateTest(t *testing.T) func(t *testing.T) {
+func setupCacheTest(t *testing.T) func() {
 	testExecutor = &mockOptionsExecutor{}
-
 	curDir, err := os.Getwd()
 	if err != nil {
 		t.Fatalf("cannot get the working dir %s: %v", curDir, err)
@@ -170,13 +156,7 @@ func setupGenerateTest(t *testing.T) func(t *testing.T) {
 		t.Fatalf("cannot copy %s for the test: %v", configTomlFile, err)
 	}
 
-	setup.Init()
-
-	origEnvXdgRuntimeDir := getXdgRuntimeDir()
-	fmt.Println("Env XDG_RUNTIME_DIR: ", origEnvXdgRuntimeDir)
-
-	// change it to the current working directory
-	os.Setenv(envXdgRuntimeDir, curDir)
+	_ = setup.Init()
 
 	origScratchDir := pkiInitScratchDir
 	testScratchDir, tempDirErr := ioutil.TempDir(curDir, "scratch")
@@ -192,6 +172,16 @@ func setupGenerateTest(t *testing.T) func(t *testing.T) {
 	}
 	pkiInitGeneratedDir = filepath.Base(testGeneratedDir)
 
+	origEnvXdgRuntimeDir := os.Getenv(envXdgRuntimeDir)
+	// change it to the current working directory
+	os.Setenv(envXdgRuntimeDir, curDir)
+
+	origEnvPkiCache := os.Getenv(envPkiCache)
+	// use curDir/cache as the working directory for test
+	pkiCacheDir := filepath.Join(curDir, "cache")
+	os.Setenv(envPkiCache, pkiCacheDir)
+	_ = createDirectoryIfNotExists(pkiCacheDir)
+
 	origDeployDir := pkiInitDeployDir
 	tempDir, tempDirErr := ioutil.TempDir(curDir, "deploytest")
 	if tempDirErr != nil {
@@ -199,14 +189,16 @@ func setupGenerateTest(t *testing.T) func(t *testing.T) {
 	}
 	pkiInitDeployDir = tempDir
 
-	return func(t *testing.T) {
+	return func() {
 		// cleanup
 		os.Remove(jsonVaultFile)
 		os.Remove(jsonKongFile)
 		os.Setenv(envXdgRuntimeDir, origEnvXdgRuntimeDir)
+		os.Setenv(envPkiCache, origEnvPkiCache)
+		os.RemoveAll(pkiInitDeployDir)
+		os.RemoveAll(pkiCacheDir)
 		os.RemoveAll(testScratchDir)
 		os.RemoveAll(testGeneratedDir)
-		os.RemoveAll(pkiInitDeployDir)
 		os.RemoveAll(testResourceDir)
 		pkiInitScratchDir = origScratchDir
 		pkiInitGeneratedDir = origGeneratedDir

--- a/internal/security/setup/option/constant.go
+++ b/internal/security/setup/option/constant.go
@@ -17,6 +17,7 @@
 package option
 
 import (
+	"errors"
 	"path/filepath"
 )
 
@@ -31,6 +32,8 @@ const (
 	envXdgRuntimeDir              = "XDG_RUNTIME_DIR"
 	defaultXdgRuntimeDir          = "/tmp"
 	pkiInitBaseDir                = "/edgex/security-secrets-setup"
+	envPkiCache                   = "PKI_CACHE"
+	defaultPkiCacheDir            = "/etc/edgex/pki"
 	tmpfsRunDir                   = "/run"
 	tlsSecretFileName             = "server.key"
 	tlsCertFileName               = "server.crt"
@@ -44,7 +47,8 @@ const (
 )
 
 var (
-	pkiInitScratchDir   = filepath.Join(pkiInitBaseDir, "scratch")
-	pkiInitGeneratedDir = filepath.Join(pkiInitBaseDir, "generated")
-	pkiInitDeployDir    = filepath.Join(tmpfsRunDir, "edgex", "secrets")
+	pkiInitScratchDir      = filepath.Join(pkiInitBaseDir, "scratch")
+	pkiInitGeneratedDir    = filepath.Join(pkiInitBaseDir, "generated")
+	pkiInitDeployDir       = filepath.Join(tmpfsRunDir, "edgex", "secrets")
+	errCacheNotChangeAfter = errors.New("PKI cache cannot be changed after it was cached previously")
 )

--- a/internal/security/setup/option/generate.go
+++ b/internal/security/setup/option/generate.go
@@ -13,6 +13,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0'
 //
+
 package option
 
 import (

--- a/internal/security/setup/option/import.go
+++ b/internal/security/setup/option/import.go
@@ -1,0 +1,112 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0'
+//
+
+package option
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/edgexfoundry/edgex-go/internal/security/setup"
+	"github.com/fsnotify/fsnotify"
+)
+
+// Import deploys PKI from CacheDir to DeployDir.  If CacheDir is empty,
+// import blocks until the PKI assets shown in CacheDir;
+// otherwise it just copies PKI assets from CacheDir into DeployDir.
+func Import() func(*PkiInitOption) (exitCode, error) {
+	return func(pkiInitOpton *PkiInitOption) (exitCode, error) {
+
+		if isImportNoOp(pkiInitOpton) {
+			return normal, nil
+		}
+
+		return importPkis()
+	}
+}
+
+func isImportNoOp(pkiInitOption *PkiInitOption) bool {
+	// nop: if the flag is missing or not on
+	return pkiInitOption == nil || !pkiInitOption.ImportOpt
+}
+
+func importPkis() (statusCode exitCode, err error) {
+	pkiCacheDir := getPkiCacheDirEnv()
+	setup.LoggingClient.Info(fmt.Sprintf("PKI_CACHE: %s", pkiCacheDir))
+
+	dirEmpty, err := isDirEmpty(pkiCacheDir)
+
+	if err != nil {
+		return exitWithError, err
+	}
+
+	if dirEmpty {
+
+		pkiCacheWatcher, err := fsnotify.NewWatcher()
+
+		if err != nil {
+			return exitWithError, err
+		}
+		defer pkiCacheWatcher.Close()
+
+		done := make(chan bool)
+
+		go func() {
+			for {
+				select {
+				case event := <-pkiCacheWatcher.Events:
+					if event.Name == "" { // skip if event name is empty
+						continue
+					}
+					setup.LoggingClient.Debug(fmt.Sprintf("watcher event: %#v\n", event))
+					// wait for some time before the directory settle down on the source side
+					// as the whole directory tree is just dropped in
+					time.Sleep(3 * time.Second)
+
+					err = deploy(pkiCacheDir, pkiInitDeployDir)
+					if err != nil {
+						statusCode = exitWithError
+					} else {
+						statusCode = normal
+					}
+					done <- true
+				case watcherErr := <-pkiCacheWatcher.Errors:
+					if watcherErr == nil {
+						continue
+					}
+					setup.LoggingClient.Error(fmt.Sprintf("watcher error: %v\n", watcherErr))
+					statusCode = exitWithError
+					err = watcherErr
+					done <- true
+				}
+			}
+		}()
+
+		if err := pkiCacheWatcher.Add(pkiCacheDir); err != nil {
+			return exitWithError, err
+		}
+
+		<-done
+	} else {
+		// copy stuff into dest dir from pkiCache
+		err = deploy(pkiCacheDir, pkiInitDeployDir)
+		if err != nil {
+			statusCode = exitWithError
+		}
+	}
+
+	return statusCode, err
+}

--- a/internal/security/setup/option/import_test.go
+++ b/internal/security/setup/option/import_test.go
@@ -1,0 +1,203 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0'
+//
+
+package option
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestImportPriorFileChange(t *testing.T) {
+	// this test case is for import running first
+	// and waiting for files from PKI_CACHE dir to be appeared
+
+	tearDown := setupImportTest(t)
+	defer tearDown()
+
+	options := PkiInitOption{
+		ImportOpt: true,
+	}
+	importOn, _, _ := NewPkiInitOption(options)
+	importOn.setExecutor(testExecutor)
+
+	var exitStatus exitCode
+	var err error
+	go func() { // in a gorountine, so it won't block
+		f := Import()
+		exitStatus, err = f(importOn.(*PkiInitOption))
+	}()
+
+	// to allow time for go func() to be properly initialized
+	time.Sleep(time.Second)
+
+	// now put a testFile into cache dir
+	writeTestFileToCacheDir(t)
+
+	// to allow time to finish deploy in another go-routine
+	time.Sleep(5 * time.Second)
+
+	deployEmpty, emptyErr := isDirEmpty(pkiInitDeployDir)
+
+	assert := assert.New(t)
+	assert.Equal(normal, exitStatus)
+	assert.Nil(err)
+	assert.Nil(emptyErr)
+	assert.False(deployEmpty)
+}
+
+func TestImportPostFileChange(t *testing.T) {
+	// this test case is for import running later
+	// files from PKI_CACHE dir are already in-place before import is called
+
+	tearDown := setupImportTest(t)
+	defer tearDown()
+
+	// put some test file into the cache dir first
+	writeTestFileToCacheDir(t)
+
+	options := PkiInitOption{
+		ImportOpt: true,
+	}
+	importOn, _, _ := NewPkiInitOption(options)
+	importOn.setExecutor(testExecutor)
+
+	f := Import()
+
+	exitStatus, err := f(importOn.(*PkiInitOption))
+
+	deployEmpty, emptyErr := isDirEmpty(pkiInitDeployDir)
+
+	assert := assert.New(t)
+	assert.Equal(normal, exitStatus)
+	assert.Nil(err)
+	assert.Nil(emptyErr)
+	assert.False(deployEmpty)
+}
+
+func TestEmptyPkiCacheEnvironment(t *testing.T) {
+	options := PkiInitOption{
+		ImportOpt: true,
+	}
+	importOn, _, _ := NewPkiInitOption(options)
+	importOn.setExecutor(testExecutor)
+	exitCode, err := importOn.executeOptions(Import())
+
+	// when PKI_CACHE env is empty, it leads to non-existing dir
+	// and should be an error case
+	assert := assert.New(t)
+	assert.NotNil(err)
+	assert.Equal(exitWithError, exitCode)
+}
+
+func TestImportOff(t *testing.T) {
+	tearDown := setupImportTest(t)
+	defer tearDown()
+
+	options := PkiInitOption{
+		ImportOpt: false,
+	}
+	importOff, _, _ := NewPkiInitOption(options)
+	importOff.setExecutor(testExecutor)
+	exitCode, err := importOff.executeOptions(Import())
+
+	assert := assert.New(t)
+	assert.Equal(normal, exitCode)
+	assert.Nil(err)
+}
+
+func TestIsDirEmpty(t *testing.T) {
+	assert := assert.New(t)
+	_, err := isDirEmpty("/non/existing/dir/")
+
+	assert.NotNil(err)
+
+	// put some test file into the current dir to trigger event
+	curDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("cannot get the working dir %s: %v", curDir, err)
+	}
+	empty, err := isDirEmpty(curDir)
+	assert.Nil(err)
+	assert.False(empty)
+
+	// create an empty temp dir
+	tempDir, err := ioutil.TempDir(curDir, "test")
+	if err != nil {
+		t.Fatalf("cannot create the temporary dir %s: %v", tempDir, err)
+	}
+	empty, err = isDirEmpty(tempDir)
+	defer func() {
+		// remove tempDir:
+		os.RemoveAll(tempDir)
+	}()
+
+	assert.Nil(err)
+	assert.True(empty)
+}
+
+func setupImportTest(t *testing.T) func() {
+	testExecutor = &mockOptionsExecutor{}
+	curDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("cannot get the working dir %s: %v", curDir, err)
+	}
+
+	origEnvXdgRuntimeDir := os.Getenv(envXdgRuntimeDir)
+	// change it to the current working directory
+	os.Setenv(envXdgRuntimeDir, curDir)
+
+	origEnvPkiCache := os.Getenv(envPkiCache)
+	// use curDir/cache as the working directory for test
+	pkiCacheDir := filepath.Join(curDir, "cache")
+	os.Setenv(envPkiCache, pkiCacheDir)
+	if err := createDirectoryIfNotExists(pkiCacheDir); err != nil {
+		t.Fatalf("cannot create the PKI_CACHE dir %s: %v", pkiCacheDir, err)
+	}
+
+	origDeployDir := pkiInitDeployDir
+	tempDir, tempDirErr := ioutil.TempDir(curDir, "deploytest")
+	if tempDirErr != nil {
+		t.Fatalf("cannot create temporary scratch directory for the test: %v", tempDirErr)
+	}
+	pkiInitDeployDir = tempDir
+
+	return func() {
+		// cleanup
+		os.Setenv(envXdgRuntimeDir, origEnvXdgRuntimeDir)
+		os.Setenv(envPkiCache, origEnvPkiCache)
+		os.RemoveAll(pkiInitDeployDir)
+		os.RemoveAll(pkiCacheDir)
+		pkiInitDeployDir = origDeployDir
+	}
+}
+
+func writeTestFileToCacheDir(t *testing.T) {
+	pkiCacheDir := os.Getenv(envPkiCache)
+	// make a test dir
+	testFileDir := filepath.Join(pkiCacheDir, "test", caServiceName)
+	_ = createDirectoryIfNotExists(testFileDir)
+	testFile := filepath.Join(testFileDir, "testFile")
+	testData := []byte("test data\n")
+	if err := ioutil.WriteFile(testFile, testData, 0644); err != nil {
+		t.Fatalf("cannot write testData to direcotry %s: %v", pkiCacheDir, err)
+	}
+}

--- a/internal/security/setup/option/mock_OptionsExecutor_test.go
+++ b/internal/security/setup/option/mock_OptionsExecutor_test.go
@@ -72,3 +72,7 @@ func (_m *mockOptionsExecutor) executeOptions(_a0 ...func(*PkiInitOption) (exitC
 
 	return r0, r1
 }
+
+func (_m *mockOptionsExecutor) setExecutor(executor OptionsExecutor) {
+	// no-op
+}

--- a/internal/security/setup/option/optionHelpers.go
+++ b/internal/security/setup/option/optionHelpers.go
@@ -18,11 +18,9 @@ package option
 
 import (
 	"errors"
-
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
 	"os"
 	"path"
 	"path/filepath"
@@ -121,7 +119,7 @@ func copyDir(srcDir, destDir string) error {
 				return err
 			}
 		} else {
-			log.Printf("copying srcFilePath: %s to destFilePath: %s", srcFilePath, destFilePath)
+			setup.LoggingClient.Debug(fmt.Sprintf("copying srcFilePath: %s to destFilePath: %s", srcFilePath, destFilePath))
 			if _, copyErr := copyFile(srcFilePath, destFilePath); copyErr != nil {
 				return copyErr
 			}
@@ -222,6 +220,14 @@ func getXdgRuntimeDir() string {
 	}
 	// if $XDG_RUNTIME_DIR is undefined, default to /tmp
 	return defaultXdgRuntimeDir
+}
+
+func getPkiCacheDirEnv() string {
+	pkiCacheDir := os.Getenv(envPkiCache)
+	if pkiCacheDir == "" {
+		return defaultPkiCacheDir
+	}
+	return pkiCacheDir
 }
 
 // GenTLSAssets generates the TLS assets based on the JSON configuration file

--- a/internal/security/setup/option/pkiOption.go
+++ b/internal/security/setup/option/pkiOption.go
@@ -31,14 +31,25 @@ type OptionsExecutor interface {
 type PkiInitOption struct {
 	GenerateOpt bool
 	CacheOpt    bool
+	ImportOpt   bool
 	executor    OptionsExecutor
 }
 
 // NewPkiInitOption constructor to get options built for pki-init
 func NewPkiInitOption(opts PkiInitOption) (ex OptionsExecutor, statusCode int, err error) {
-	// cache option cannot used with -generate
+	// cache option cannot be used with -generate
 	if opts.CacheOpt && opts.GenerateOpt {
-		return ex, exitWithError.intValue(), errors.New("Cannot execute cache option with generate option")
+		return ex, exitWithError.intValue(), errors.New("Cannot use cache option with generate option at the same time")
+	}
+
+	// import option cannot be used with -generate
+	if opts.ImportOpt && opts.GenerateOpt {
+		return ex, exitWithError.intValue(), errors.New("Cannot use import option with generate option at the same time")
+	}
+
+	// import option cannot be used with -cache, either
+	if opts.ImportOpt && opts.CacheOpt {
+		return ex, exitWithError.intValue(), errors.New("Cannot use import option with cache option at the same time")
 	}
 
 	opts.executor = &opts
@@ -51,6 +62,7 @@ func (pkiInitOpt *PkiInitOption) ProcessOptions() (int, error) {
 	statusCode, err := pkiInitOpt.executor.executeOptions(
 		Generate(),
 		Cache(),
+		Import(),
 	)
 
 	return statusCode.intValue(), err

--- a/internal/security/setup/option/pkiOption_test.go
+++ b/internal/security/setup/option/pkiOption_test.go
@@ -62,11 +62,70 @@ func TestNewPkiInitOption_CacheOnly(t *testing.T) {
 	assert.Equal(false, optionsExecutor.(*PkiInitOption).CacheOpt)
 }
 
+func TestNewPkiInitOption_ImportOnly(t *testing.T) {
+	assert := assert.New(t)
+
+	options := PkiInitOption{
+		ImportOpt: true,
+	}
+	// import option given
+	optionsExecutor, _, _ := NewPkiInitOption(options)
+	assert.NotNil(optionsExecutor)
+	assert.Equal(true, optionsExecutor.(*PkiInitOption).ImportOpt)
+
+	// import option omitted
+	options.ImportOpt = false
+	optionsExecutor, _, _ = NewPkiInitOption(options)
+	assert.NotNil(optionsExecutor)
+	assert.Equal(false, optionsExecutor.(*PkiInitOption).ImportOpt)
+}
+
 func TestNewPkiInitOption_CacheAndGenerate(t *testing.T) {
 	assert := assert.New(t)
 
 	options := PkiInitOption{
 		GenerateOpt: true,
+		CacheOpt:    true,
+	}
+	optionsExecutor, status, err := NewPkiInitOption(options)
+	assert.Empty(optionsExecutor)
+	assert.Equal(exitWithError.intValue(), status)
+	assert.NotNil(err)
+}
+
+func TestNewPkiInitOption_ImportAndGenerate(t *testing.T) {
+	assert := assert.New(t)
+
+	options := PkiInitOption{
+		GenerateOpt: true,
+		ImportOpt:   true,
+	}
+	// import and generate option given
+	optionsExecutor, status, err := NewPkiInitOption(options)
+	assert.Empty(optionsExecutor)
+	assert.Equal(exitWithError.intValue(), status)
+	assert.NotNil(err)
+}
+
+func TestNewPkiInitOption_CacheAndImport(t *testing.T) {
+	assert := assert.New(t)
+
+	options := PkiInitOption{
+		ImportOpt: true,
+		CacheOpt:  true,
+	}
+	optionsExecutor, status, err := NewPkiInitOption(options)
+	assert.Empty(optionsExecutor)
+	assert.Equal(exitWithError.intValue(), status)
+	assert.NotNil(err)
+}
+
+func TestNewPkiInitOption_CacheAndGenerateAndImport(t *testing.T) {
+	assert := assert.New(t)
+
+	options := PkiInitOption{
+		GenerateOpt: true,
+		ImportOpt:   true,
 		CacheOpt:    true,
 	}
 	optionsExecutor, status, err := NewPkiInitOption(options)

--- a/internal/security/setup/option/pkiOption_test.go
+++ b/internal/security/setup/option/pkiOption_test.go
@@ -44,21 +44,37 @@ func TestNewPkiInitOption_GenerateOnly(t *testing.T) {
 	assert.Equal(false, generateOff.(*PkiInitOption).GenerateOpt)
 }
 
-func getMockArguments() []interface{} {
-	var ifc []interface{}
-	// use reflection to find out how many bool type of options in PkiInitOption struct
-	// and create a slice of mock argument interface instances
-	elm := reflect.ValueOf(&PkiInitOption{}).Elem()
-	for i := 0; i < elm.NumField(); i++ {
-		field := elm.Field(i)
-		switch field.Kind() {
-		case reflect.Bool:
-			ifc = append(ifc, mock.AnythingOfTypeArgument("func(*option.PkiInitOption) (option.exitCode, error)"))
-		}
-	}
+func TestNewPkiInitOption_CacheOnly(t *testing.T) {
+	assert := assert.New(t)
 
-	return ifc
+	options := PkiInitOption{
+		CacheOpt: true,
+	}
+	// cache option given
+	optionsExecutor, _, _ := NewPkiInitOption(options)
+	assert.NotNil(optionsExecutor)
+	assert.Equal(true, optionsExecutor.(*PkiInitOption).CacheOpt)
+
+	// cache option omitted
+	options.CacheOpt = false
+	optionsExecutor, _, _ = NewPkiInitOption(options)
+	assert.NotNil(optionsExecutor)
+	assert.Equal(false, optionsExecutor.(*PkiInitOption).CacheOpt)
 }
+
+func TestNewPkiInitOption_CacheAndGenerate(t *testing.T) {
+	assert := assert.New(t)
+
+	options := PkiInitOption{
+		GenerateOpt: true,
+		CacheOpt:    true,
+	}
+	optionsExecutor, status, err := NewPkiInitOption(options)
+	assert.Empty(optionsExecutor)
+	assert.Equal(exitWithError.intValue(), status)
+	assert.NotNil(err)
+}
+
 func TestProcessOptionNormal(t *testing.T) {
 	testExecutor := &mockOptionsExecutor{}
 	// normal case
@@ -71,7 +87,7 @@ func TestProcessOptionNormal(t *testing.T) {
 		GenerateOpt: true,
 	}
 	optsExecutor, _, _ := NewPkiInitOption(options)
-	optsExecutor.(*PkiInitOption).executor = testExecutor
+	optsExecutor.setExecutor(testExecutor)
 	exitCode, err := optsExecutor.ProcessOptions()
 	assert.Equal(normal.intValue(), exitCode)
 	assert.Nil(err)
@@ -92,7 +108,8 @@ func TestProcessOptionError(t *testing.T) {
 		GenerateOpt: true,
 	}
 	generateOn, _, _ := NewPkiInitOption(options)
-	generateOn.(*PkiInitOption).executor = testExecutor
+
+	generateOn.setExecutor(testExecutor)
 	exitCode, err := generateOn.ProcessOptions()
 	assert.Equal(exitWithError.intValue(), exitCode)
 	assert.Equal(generateErr, err)
@@ -108,17 +125,33 @@ func TestExecuteOption(t *testing.T) {
 		GenerateOpt: true,
 	}
 	generateOn, _, _ := NewPkiInitOption(options)
-	generateOn.(*PkiInitOption).executor = testExecutor
+	generateOn.setExecutor(testExecutor)
 	exitCode, err := generateOn.executeOptions(mockGenerate())
 	assert.Equal(normal, exitCode)
 	assert.Nil(err)
 
 	options.GenerateOpt = false
 	generateOff, _, _ := NewPkiInitOption(options)
-	generateOff.(*PkiInitOption).executor = testExecutor
+	generateOff.setExecutor(testExecutor)
 	exitCode, err = generateOff.executeOptions(mockGenerate())
 	assert.Equal(normal, exitCode)
 	assert.Nil(err)
+}
+
+func getMockArguments() []interface{} {
+	var ifc []interface{}
+	// use reflection to find out how many bool type of options in PkiInitOption struct
+	// and create a slice of mock argument interface instances
+	elm := reflect.ValueOf(&PkiInitOption{}).Elem()
+	for i := 0; i < elm.NumField(); i++ {
+		field := elm.Field(i)
+		switch field.Kind() {
+		case reflect.Bool:
+			ifc = append(ifc, mock.AnythingOfTypeArgument("func(*option.PkiInitOption) (option.exitCode, error)"))
+		}
+	}
+
+	return ifc
 }
 
 func mockGenerate() func(*PkiInitOption) (exitCode, error) {


### PR DESCRIPTION
Add import option from merging pki-init into security-secrets-setup.

New library of `fsnotify/fsnotify` is introduced and used for checking the file changes on the file system.
(Have to modify all the Attribution.txt under all services although they are irrelevant in order to pass the make test checking gate) .  This issue should be brought up in Core-working group meeting and create an open issue to refactor the shell script under `./bin/test-attribution-txt.sh` to be more efficient and accurate.

Signed-off-by: Jim Wang <yutsung.jim.wang@intel.com>