### PR TITLE
feat(security): Boiler-plate for implementating security container install on security bootstrapping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,8 +30,12 @@ cmd/sys-mgmt-agent/sys-mgmt-agent
 cmd/sys-mgmt-executor/sys-mgmt-executor
 cmd/security-bootstrap-redis/security-bootstrap-redis
 cmd/secrets-config/secrets-config
+cmd/security-bootstrapper/security-bootstrapper
 
 docs/_build/
+
+zeromq-*/
+zmqlib_setup.sh
 
 # log dirs
 **/logs

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,8 @@ DOCKERS= \
 	docker_security_secrets_setup \
 	docker_security_proxy_setup \
 	docker_security_secretstore_setup \
-	docker_security_bootstrap_redis
+	docker_security_bootstrap_redis \
+	docker_security_bootstrapper
 
 .PHONY: $(DOCKERS)
 
@@ -37,7 +38,8 @@ MICROSERVICES= \
 	cmd/security-secretstore-setup/security-secretstore-setup \
 	cmd/security-file-token-provider/security-file-token-provider \
 	cmd/security-bootstrap-redis/security-bootstrap-redis \
-	cmd/secrets-config/secrets-config
+	cmd/secrets-config/secrets-config \
+	cmd/security-bootstrapper/security-bootstrapper
 
 .PHONY: $(MICROSERVICES)
 
@@ -91,6 +93,9 @@ cmd/security-bootstrap-redis/security-bootstrap-redis:
 
 cmd/secrets-config/secrets-config:
 	$(GO) build $(GOFLAGS) -o ./cmd/secrets-config ./cmd/secrets-config
+	
+cmd/security-bootstrapper/security-bootstrapper:
+	$(GO) build $(GOFLAGS) -o ./cmd/security-bootstrapper/security-bootstrapper ./cmd/security-bootstrapper
 
 clean:
 	rm -f $(MICROSERVICES)
@@ -208,3 +213,14 @@ docker_security_bootstrap_redis:
 		-t edgexfoundry/docker-security-bootstrap-redis-go:$(GIT_SHA) \
 		-t edgexfoundry/docker-security-bootstrap-redis-go:$(DOCKER_TAG) \
 		.
+
+docker_security_bootstrapper:
+	docker build \
+	    --build-arg http_proxy \
+	    --build-arg https_proxy \
+		-f cmd/security-bootstrapper/Dockerfile \
+		--label "git_sha=$(GIT_SHA)" \
+		-t edgexfoundry/docker-security-bootstrapper-go:$(GIT_SHA) \
+		-t edgexfoundry/docker-security-bootstrapper-go:$(DOCKER_TAG) \
+		.
+		

--- a/cmd/security-bootstrapper/Attribution.txt
+++ b/cmd/security-bootstrapper/Attribution.txt
@@ -1,0 +1,176 @@
+The following open source projects are referenced by Security Secrets Setup:
+
+pkg/errors (BSD-2) https://github.com/pkg/errors
+https://github.com/pkg/errors/blob/master/LICENSE
+
+gorilla/mux (BSD-3) - https://github.com/gorilla/mux
+https://github.com/gorilla/mux/blob/master/LICENSE
+
+globalsign/mgo (unspecified) - https://github.com/globalsign/mgo
+https://github.com/globalsign/mgo/blob/master/LICENSE
+
+pebbe/zmq4 (BSD-2) https://github.com/pebbe/zmq4
+https://github.com/pebbe/zmq4/blob/master/LICENSE.txt
+
+go-kit/kit (MIT) github.com/go-kit/kit
+https://github.com/go-kit/kit/blob/master/LICENSE
+
+go-logfmt/logfmt (MIT) https://github.com/go-logfmt/logfmt
+https://github.com/go-logfmt/logfmt/blob/master/LICENSE
+
+robfig/cron (MIT) https://github.com/robfig/cron
+https://github.com/robfig/cron/blob/master/LICENSE
+
+dgrijalva/jwt-go (MIT) https://github.com/dgrijalva/jwt-go
+https://github.com/dgrijalva/jwt-go/blob/master/LICENSE
+
+google/uuid (BSD-3) https://github.com/google/uuid
+https://github.com/google/uuid/blob/master/LICENSE
+
+pelletier/go-toml (MIT) https://github.com/pelletier/go-toml
+https://github.com/pelletier/go-toml/blob/master/LICENSE
+
+influxdata/influxdb/client/v2 (MIT) https://github.com/influxdata/influxdb
+https://github.com/influxdata/influxdb/blob/master/LICENSE
+
+influxdata/platform (MIT) https://github.com/influxdata/platform
+https://github.com/influxdata/platform/blob/master/LICENSE
+
+eclipse/paho.mqtt.golang (Eclipse Public License 1.0) https://github.com/eclipse/paho.mqtt.golang
+https://github.com/eclipse/paho.mqtt.golang/blob/master/LICENSE
+
+mattn/go-xmpp (BSD-3) https://github.com/mattn/go-xmpp
+https://github.com/mattn/go-xmpp/blob/master/LICENSE
+
+BurntSushi/toml (MIT) https://github.com/BurntSushi/toml
+https://github.com/BurntSushi/toml/blob/master/COPYING
+
+mitchellh/consulstructure (MIT) https://github.com/mitchellh/consulstructure
+https://github.com/mitchellh/consulstructure/blob/master/LICENSE
+
+mitchellh/mapstructure (MIT) https://github.com/mitchellh/mapstructure
+https://github.com/mitchellh/mapstructure/blob/master/LICENSE
+
+mitchellh/copystructure (MIT) https://github.com/mitchellh/copystructure
+https://github.com/mitchellh/copystructure/blob/master/LICENSE
+
+mitchellh/reflectwalk (MIT) https://github.com/mitchellh/reflectwalk
+https://github.com/mitchellh/reflectwalk/blob/master/LICENSE
+
+cenkalti/backoff (MIT) https://github.com/cenkalti/backoff
+https://github.com/cenkalti/backoff/blob/master/LICENSE
+
+hashicorp/consul/api 1.1.0 (Mozilla Public License 2.0) - https://github.com/hashicorp/consul/api
+https://github.com/hashicorp/consul/blob/master/LICENSE
+
+hashicorp/go-cleanhttp (Mozilla Public License 2.0) - https://github.com/hashicorp/go-cleanhttp
+https://github.com/hashicorp/go-cleanhttp/blob/master/LICENSE
+
+hashicorp/go-rootcerts (Mozilla Public License 2.0) https://github.com/hashicorp/go-rootcerts
+https://github.com/hashicorp/go-rootcerts/blob/master/LICENSE
+
+mitchellh/go-homedir (MIT) https://github.com/mitchellh/go-homedir
+https://github.com/mitchellh/go-homedir/blob/master/LICENSE
+
+mitchellh/mapstructure (MIT) https://github.com/mitchellh/mapstructure
+https://github.com/mitchellh/mapstructure/blob/master/LICENSE
+
+hashicorp/serf (Mozilla Public License 2.0) https://github.com/hashicorp/serf
+https://github.com/hashicorp/serf/blob/master/LICENSE
+
+armon/go-metrics (MIT) https://github.com/armon/go-metrics
+https://github.com/armon/go-metrics/blob/master/LICENSE
+
+hashicorp/go-immutable-radix (Mozilla Public License 2.0) https://github.com/hashicorp/go-immutable-radix
+https://github.com/hashicorp/go-immutable-radix/blob/master/LICENSE
+
+hashicorp/golang-lru (Mozilla Public License 2.0) https://github.com/hashicorp/golang-lru
+https://github.com/hashicorp/golang-lru/blob/master/LICENSE
+
+github.com/go-redis/redis/v7 (BSD-2) https://github.com/go-redis/redis
+https://github.com/go-redis/redis/blob/master/LICENSE
+https://github.com/go-redis/redis/blob/master/LICENSE
+
+gomodule/redigo (Apache 2.0) https://github.com/gomodule/redigo
+https://github.com/gomodule/redigo/blob/master/LICENSE
+
+OneOfOne/xxhash (Apache 2.0) https://github.com/OneOfOne/xxhash
+https://github.com/OneOfOne/xxhash/blob/master/LICENSE
+
+imdario/mergo (BSD-3) github.com/imdario/mergo
+https://github.com/imdario/mergo/blob/master/LICENSE
+
+magiconair/properties (BSD-2) https://github.com/magiconair/properties
+https://github.com/magiconair/properties/blob/master/LICENSE
+
+gopkg.in/eapache/queue.v1 (MIT) gopkg.in/eapache/queue.v1
+https://github.com/eapache/queue/blob/v1.1.0/LICENSE
+
+bertimus9/systemstat (MIT) https://bitbucket.org/bertimus9/systemstat
+https://bitbucket.org/bertimus9/systemstat/src/master/LICENSE
+
+davecgh/go-spew (ISC) https://github.com/davecgh/go-spew
+https://github.com/davecgh/go-spew/blob/master/LICENSE
+
+edgexfoundry/go-mod-bootstrap (Apache 2.0) https://github.com/edgexfoundry/go-mod-bootstrap
+https://github.com/edgexfoundry/go-mod-bootstrap/blob/master/LICENSE
+
+edgexfoundry/go-mod-configuration (Apache 2.0) https://github.com/edgexfoundry/go-mod-configuration
+https://github.com/edgexfoundry/go-mod-configuration/blob/master/LICENSE
+
+edgexfoundry/go-mod-core-contracts (Apache 2.0) https://github.com/edgexfoundry/go-mod-core-contracts
+https://github.com/edgexfoundry/go-mod-core-contracts/blob/master/LICENSE
+
+edgexfoundry/go-mod-messaging (Apache 2.0) https://github.com/edgexfoundry/go-mod-messaging
+https://github.com/edgexfoundry/go-mod-messaging/blob/master/LICENSE
+
+edgexfoundry/go-mod-registry (Apache 2.0) https://github.com/edgexfoundry/go-mod-registry
+https://github.com/edgexfoundry/go-mod-registry/blob/master/LICENSE
+
+edgexfoundry/go-mod-secrets (Apache 2.0) https://github.com/edgexfoundry/go-mod-secrets
+https://github.com/edgexfoundry/go-mod-secrets/blob/master/LICENSE
+
+gorilla/context (BSD-3) https://github.com/gorilla/context
+https://github.com/gorilla/context/blob/master/LICENSE
+
+kr/logfmt (Unspecified) https://github.com/kr/logfmt
+https://github.com/kr/logfmt/blob/master/Readme
+
+pmezard/go-difflib (Unspecified) https://github.com/pmezard/go-difflib
+https://github.com/pmezard/go-difflib/blob/master/LICENSE
+
+stretchr/objx (MIT) https://github.com/stretchr/objx
+https://github.com/stretchr/objx/blob/master/LICENSE
+
+stretchr/testify (MIT) https://github.com/stretchr/testify
+https://github.com/stretchr/testify/blob/master/LICENSE
+
+fxamacker/cbor (MIT) https://github.com/fxamacker/cbor/v2
+https://github.com/fxamacker/cbor/blob/master/README.md#license
+
+x448/float16 (MIT) https://github.com/x448/float16
+https://github.com/x448/float16/blob/master/LICENSE
+
+golang.org/x/net (Unspecified) https://github.com/golang/net
+https://github.com/golang/net/blob/master/LICENSE
+
+gopkg.in/yaml.v2 (Apache 2.0) https://github.com/go-yaml/yaml/
+https://github.com/go-yaml/yaml/blob/v2.2.2/LICENSE
+
+cloudflare/gokey (BSD-3) https://github.com/cloudflare/gokey
+https://github.com/cloudflare/gokey/blob/master/LICENSE
+
+golang.org/x/crypto (Unspecified) https://github.com/golang/crypto
+https://github.com/golang/crypto/blob/master/LICENSE
+
+go-playground/locales (MIT) https://github.com/go-playground/locales
+https://github.com/go-playground/locales/blob/master/LICENSE
+
+go-playground/universal-translator (MIT) https://github.com/go-playground/universal-translator
+https://github.com/go-playground/universal-translator/blob/master/LICENSE
+
+github.com/go-playground/validator/v10 (MIT) https://github.com/go-playground/validator
+https://github.com/go-playground/validator/blob/master/LICENSE
+
+leodido/go-urn (MIT) https://github.com/leodido/go-urn
+https://github.com/leodido/go-urn

--- a/cmd/security-bootstrapper/Dockerfile
+++ b/cmd/security-bootstrapper/Dockerfile
@@ -1,0 +1,67 @@
+#  ----------------------------------------------------------------------------------
+#  Copyright 2020 Intel Corp.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+#
+#  SPDX-License-Identifier: Apache-2.0'
+#  ----------------------------------------------------------------------------------
+
+ARG BUILDER_BASE=golang:1.15-alpine
+FROM ${BUILDER_BASE} AS builder
+
+WORKDIR /edgex-go
+
+RUN sed -e 's/dl-cdn[.]alpinelinux.org/nl.alpinelinux.org/g' -i~ /etc/apk/repositories
+
+RUN apk update && apk add make git
+
+COPY go.mod .
+
+RUN go mod download
+
+COPY . .
+
+RUN make cmd/security-bootstrapper/security-bootstrapper
+
+FROM alpine
+
+RUN apk update && apk add dumb-init openssl \
+    && rm -rf /var/cache/apk/* 
+
+LABEL license='SPDX-License-Identifier: Apache-2.0' \
+      copyright='Copyright (c) 2020 Intel Corporation'
+
+
+ENV DOCKERIZE_VERSION v0.6.1
+RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+    && tar -C /usr/local/bin -xzvf dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+    && rm dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz
+
+WORKDIR /edgex
+
+RUN mkdir -p /edgex-init && \
+    mkdir /edgex-staging
+
+COPY --from=builder /edgex-go/cmd/security-bootstrapper/vault_wait_install.sh /edgex-staging
+RUN chmod +x /edgex-staging/vault_wait_install.sh
+
+COPY --from=builder /edgex-go/cmd/security-bootstrapper/security-bootstrapper .
+COPY --from=builder /edgex-go/cmd/security-bootstrapper/res/configuration.toml ./res/
+
+COPY --from=builder /edgex-go/cmd/security-bootstrapper/entrypoint.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/entrypoint.sh \
+    && ln -s /usr/local/bin/entrypoint.sh /
+
+ENTRYPOINT ["entrypoint.sh"]
+CMD ["--init"]

--- a/cmd/security-bootstrapper/entrypoint.sh
+++ b/cmd/security-bootstrapper/entrypoint.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/dumb-init /bin/sh
+#  ----------------------------------------------------------------------------------
+#  Copyright (c) 2020 Intel Corporation
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+#  SPDX-License-Identifier: Apache-2.0'
+#  ----------------------------------------------------------------------------------
+set -e
+
+# function to trim off leading and trailing spaces
+trim_spaces()
+{
+  TR=$(echo -e "$1" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+  echo "${TR}"
+}
+
+# Passing the arguments to the executable
+if [ "${1:0:1}" = '-' ]; then
+    set -- security-bootstrapper "$@"
+fi
+
+# get the port numbers from the configuration toml file
+TOML_FILE="/edgex/res/configuration.toml"
+[[ -e ${TOML_FILE} ]] || { echo "${TOML_FILE} does not exist." >&2;exit 1;}
+
+IFS="="
+BOOTSTRAPPER_HOST_KEY="BootstrapperHost"
+BOOTSTRAP_PORT_KEY="BootstrapPort"
+TOKENS_READY_PORT_KEY="TokensReadyPort"
+READY_TO_RUN_PORT_KEY="ReadyToRunPort"
+bootstrapper_host=0
+bootstrap_port_number=0
+tokens_ready_port_number=0
+ready_to_run_port_number=0
+while read -r key value
+do
+  trimmed_key=$(trim_spaces "${key}")
+  trimmed_value=$(trim_spaces "${value}")
+
+  if [ "${trimmed_key}" = "${BOOTSTRAPPER_HOST_KEY}" ]; then
+    bootstrapper_host=${trimmed_value}
+  elif [ "${trimmed_key}" = "${BOOTSTRAP_PORT_KEY}" ]; then
+    bootstrap_port_number=${trimmed_value}
+  elif [ "${trimmed_key}" = "${TOKENS_READY_PORT_KEY}" ]; then
+    tokens_ready_port_number=${trimmed_value}
+  elif [ "${trimmed_key}" = "${READY_TO_RUN_PORT_KEY}" ]; then
+    ready_to_run_port_number=${trimmed_value}
+  fi
+done < ${TOML_FILE}
+
+echo bootstrapper_host: ${bootstrapper_host}
+echo bootstrap_port_number: ${bootstrap_port_number} tokens_ready_port_number: ${tokens_ready_port_number} ready_to_run_port_number:${ready_to_run_port_number}
+
+if [ "$1" = 'security-bootstrapper' ]; then
+    echo "Copy dockerize executable"
+    cp /usr/local/bin/dockerize /edgex-init/dockerize
+
+    echo 'Injecting edgex-vault entrypoint script...'
+    # prepare entrypoint script for Vault
+    cp /edgex-staging/vault_wait_install.sh /edgex-staging/tmp.sh
+    # replacing the # BOOTSTRAPPER_HOST_KEY= in the entrypoint script with the host name to be used
+    sed -i 's/# BOOTSTRAPPER_HOST=/BOOTSTRAPPER_HOST='${bootstrapper_host}'/g' /edgex-staging/tmp.sh
+    # replacing the # WAIT_TCP_PORT= in the entrypoint script with the real port number to be used
+    sed -i 's/# WAIT_TCP_PORT=/WAIT_TCP_PORT='$bootstrap_port_number'/g' /edgex-staging/tmp.sh
+    # update the wait_install script for other services waiting on listener port from installation
+    echo "Installing wait_install script"
+    cp /edgex-staging/tmp.sh /edgex-init/wait_install.sh
+    rm -f /edgex-staging/tmp.sh
+
+    echo 'TBD: injecting consul entrypoint script...'
+    # put the preparation of entrypoint script for Consul here
+    sleep 1
+    echo 'TBD: injecting postgres entrypoint script...'
+    # put the preparation of entrypoint script for Postgres here
+    sleep 1
+    echo 'TBD: injecting redis entrypoint script...'
+    # put the preparation of entrypoint script for Redis here
+    sleep 1
+    echo 'TBD: injecting kong entrypoint script...'
+    # put the preparation of entrypoint script for Kong here
+    sleep 1
+
+    echo "Executing ./$@"
+  "./$@"
+
+else 
+  # for debug purposes like docker exec -it security-bootstrapper:0.0.0-dev /bin/sh
+  echo "current directory:" $PWD
+  exec "$@"
+fi
+
+echo "Waiting for termination signal"
+exec tail -f /dev/null

--- a/cmd/security-bootstrapper/main.go
+++ b/cmd/security-bootstrapper/main.go
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright 2020 Intel Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+package main
+
+import (
+	"context"
+
+	"github.com/edgexfoundry/edgex-go/internal/security/bootstrapper"
+	"github.com/gorilla/mux"
+)
+
+func main() {
+	ctx, cancel := context.WithCancel(context.Background())
+	bootstrapper.Main(ctx, cancel, mux.NewRouter(), nil)
+}

--- a/cmd/security-bootstrapper/res/configuration.toml
+++ b/cmd/security-bootstrapper/res/configuration.toml
@@ -1,0 +1,15 @@
+[Writable]
+LogLevel = 'DEBUG'
+
+[StageGate]
+BootstrapperHost = "edgex-security-installer"
+BootstrapPort = 54321
+VaultWorkerHost = "edgex-vault-worker"
+TokensReadyPort = 54322
+ReadyToRunPort = 54323
+RedisHost = "edgex-redis"
+RedisReadyPort = 6379
+ConsulHost = "edgex-core-consul"
+ConsulReadyPort = 8500
+PostgresHost = "kong-db"
+PostgresReadyPort = 5432

--- a/cmd/security-bootstrapper/testdata/run_test.sh
+++ b/cmd/security-bootstrapper/testdata/run_test.sh
@@ -1,0 +1,48 @@
+#  ----------------------------------------------------------------------------------
+#  Copyright (c) 2020 Intel Corporation
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+#  SPDX-License-Identifier: Apache-2.0'
+#  ----------------------------------------------------------------------------------
+
+# This script is to run both security-boostrapper, listening to a certain port until the installation 
+# container signals done, and Vault containers. 
+# The Vault container will not start until the go-ahead tcp is signaled.
+
+TEST_NETWORK=test-bootstrapper-net
+docker network create --driver bridge $TEST_NETWORK
+
+docker run -d -v /edgex-init:/edgex-init \
+  --network $TEST_NETWORK \
+  --name edgex-security-installer \
+  edgexfoundry/docker-security-bootstrapper-go:0.0.0-dev
+
+docker run -d -p 8200:8200 --entrypoint="/edgex-init/wait_install.sh" \
+  -v /edgex-init:/edgex-init --name edgex-vault --cap-add=IPC_LOCK \
+  --network $TEST_NETWORK \
+  -e 'VAULT_LOCAL_CONFIG={"backend": {"file": {"path": "/vault/file"}}, "default_lease_ttl": "168h", "max_lease_ttl": "720h"}' \
+  vault:1.5.3 server
+
+sleep 2
+docker logs edgex-security-installer
+
+# give enough time to wait until Vault server is started
+sleep 15
+docker logs edgex-vault
+docker logs edgex-security-installer
+
+sleep 40
+# cleanup
+docker rm $(docker ps -aq --filter="network=$TEST_NETWORK") -f
+docker network rm $TEST_NETWORK

--- a/cmd/security-bootstrapper/vault_wait_install.sh
+++ b/cmd/security-bootstrapper/vault_wait_install.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/dumb-init /bin/sh
+#  ----------------------------------------------------------------------------------
+#  Copyright (c) 2020 Intel Corporation
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+#  SPDX-License-Identifier: Apache-2.0'
+#  ----------------------------------------------------------------------------------
+
+# This is customized entrypoint script for Vault.
+# In particular, it waits for the BootstrapPort ready to roll
+
+set -e
+
+echo "Script for waiting scurity install bootstrapping done on the listener"
+echo "the current directory is $PWD"
+
+# BOOTSTRAPPER_HOST=
+# WAIT_TCP_PORT=
+
+if [ "$1" = 'server' ]; then
+  echo "Executing dockerize on vault $@ with waiting on tcp://${BOOTSTRAPPER_HOST}:$WAIT_TCP_PORT"
+  /edgex-init/dockerize -wait tcp://${BOOTSTRAPPER_HOST}:$WAIT_TCP_PORT -timeout 60s
+  echo 'Starting edgex-vault...'
+  exec /usr/local/bin/docker-entrypoint.sh server -log-level=info
+fi

--- a/internal/security/bootstrapper/config/config.go
+++ b/internal/security/bootstrapper/config/config.go
@@ -1,0 +1,93 @@
+/*******************************************************************************
+ * Copyright 2020 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ *******************************************************************************/
+
+package config
+
+import (
+	bootstrapConfig "github.com/edgexfoundry/go-mod-bootstrap/config"
+)
+
+type ConfigurationStruct struct {
+	Writable  WritableInfo
+	StageGate StageGateInfo
+}
+
+type WritableInfo struct {
+	LogLevel string
+}
+
+type StageGateInfo struct {
+	BootstrapperHost  string
+	BootstrapPort     int
+	VaultWorkerHost   string
+	TokensReadyPort   int
+	ReadyToRunPort    int
+	RedisHost         string
+	RedisReadyPort    int
+	ConsulHost        string
+	ConsulReadyPort   int
+	PostgresHost      string
+	PostgresReadyPort int
+}
+
+// UpdateFromRaw converts configuration received from the registry to a service-specific configuration struct which is
+// then used to overwrite the service's existing configuration struct.
+func (c *ConfigurationStruct) UpdateFromRaw(rawConfig interface{}) bool {
+	configuration, ok := rawConfig.(*ConfigurationStruct)
+	if ok {
+		*c = *configuration
+	}
+	return ok
+}
+
+// EmptyWritablePtr returns a pointer to a service-specific empty WritableInfo struct.  It is used by the bootstrap to
+// provide the appropriate structure to registry.Client's WatchForChanges().
+func (c *ConfigurationStruct) EmptyWritablePtr() interface{} {
+	return &WritableInfo{}
+}
+
+// UpdateWritableFromRaw converts configuration received from the registry to a service-specific WritableInfo struct
+// which is then used to overwrite the service's existing configuration's WritableInfo struct.
+func (c *ConfigurationStruct) UpdateWritableFromRaw(rawWritable interface{}) bool {
+	writable, ok := rawWritable.(*WritableInfo)
+	if ok {
+		c.Writable = *writable
+	}
+	return ok
+}
+
+// GetBootstrap returns the configuration elements required by the bootstrap.  Currently, a copy of the configuration
+// data is returned.  This is intended to be temporary -- since ConfigurationStruct drives the configuration.toml's
+// structure -- until we can make backwards-breaking configuration.toml changes (which would consolidate these fields
+// into an bootstrapConfig.BootstrapConfiguration struct contained within ConfigurationStruct).
+func (c *ConfigurationStruct) GetBootstrap() bootstrapConfig.BootstrapConfiguration {
+	// temporary until we can make backwards-breaking configuration.toml change
+	return bootstrapConfig.BootstrapConfiguration{}
+}
+
+// GetLogLevel returns the current ConfigurationStruct's log level.
+func (c *ConfigurationStruct) GetLogLevel() string {
+	return c.Writable.LogLevel
+}
+
+// GetRegistryInfo returns the RegistryInfo from the ConfigurationStruct.
+func (c *ConfigurationStruct) GetRegistryInfo() bootstrapConfig.RegistryInfo {
+	return bootstrapConfig.RegistryInfo{}
+}
+
+// GetDatabaseInfo returns a database information map.
+func (c *ConfigurationStruct) GetDatabaseInfo() map[string]bootstrapConfig.Database {
+	return nil
+}

--- a/internal/security/bootstrapper/container/container.go
+++ b/internal/security/bootstrapper/container/container.go
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright 2020 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ *******************************************************************************/
+
+package container
+
+import (
+	"github.com/edgexfoundry/edgex-go/internal/security/bootstrapper/config"
+	"github.com/edgexfoundry/go-mod-bootstrap/di"
+)
+
+// ConfigurationName contains the name of the config.ConfigurationStruct implementation in the DIC.
+var ConfigurationName = di.TypeInstanceToName(config.ConfigurationStruct{})
+
+// ConfigurationFrom helper function queries the DIC and returns the config.ConfigurationStruct implementation.
+func ConfigurationFrom(get di.Get) *config.ConfigurationStruct {
+	return get(ConfigurationName).(*config.ConfigurationStruct)
+}

--- a/internal/security/bootstrapper/init.go
+++ b/internal/security/bootstrapper/init.go
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ * Copyright 2020 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ *******************************************************************************/
+
+package bootstrapper
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/edgexfoundry/edgex-go/internal/security/bootstrapper/container"
+
+	bootstrapContainer "github.com/edgexfoundry/go-mod-bootstrap/bootstrap/container"
+	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/startup"
+	"github.com/edgexfoundry/go-mod-bootstrap/di"
+)
+
+type Bootstrap struct {
+	initNeeded bool
+}
+
+func NewBootstrap(initNeeded bool) *Bootstrap {
+	return &Bootstrap{
+		initNeeded: initNeeded,
+	}
+}
+
+// BootstrapHandler fulfills the BootstrapHandler contract and performs initialization needed by the data service.
+func (b *Bootstrap) BootstrapHandler(_ context.Context, _ *sync.WaitGroup, _ startup.Timer, dic *di.Container) bool {
+	conf := container.ConfigurationFrom(dic.Get)
+	lc := bootstrapContainer.LoggingClientFrom(dic.Get)
+
+	if b.initNeeded {
+		lc.Debug(fmt.Sprintf("init phase done: attempts to start up the listener on bootstrap port: %d",
+			conf.StageGate.BootstrapPort))
+
+		go StartListener(conf.StageGate.BootstrapPort, lc)
+	}
+
+	// wait on for others to be done: each of tcp dialers is a blocking call
+	lc.Debug("Waiting on dependent semaphores required to raise the ready-to-run semaphore ...")
+	DialTcp(conf.StageGate.ConsulHost, conf.StageGate.ConsulReadyPort, lc)
+	DialTcp(conf.StageGate.PostgresHost, conf.StageGate.PostgresReadyPort, lc)
+	DialTcp(conf.StageGate.VaultWorkerHost, conf.StageGate.TokensReadyPort, lc)
+	DialTcp(conf.StageGate.RedisHost, conf.StageGate.RedisReadyPort, lc)
+
+	// Reached ready-to-run phase
+	lc.Debug(fmt.Sprintf("ready-to-run phase done: attempts to start up the listener on ready-to-run port: %d",
+		conf.StageGate.ReadyToRunPort))
+
+	go StartListener(conf.StageGate.ReadyToRunPort, lc)
+
+	return false
+}

--- a/internal/security/bootstrapper/main.go
+++ b/internal/security/bootstrapper/main.go
@@ -1,0 +1,78 @@
+/*******************************************************************************
+ * Copyright 2020 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ *******************************************************************************/
+
+package bootstrapper
+
+import (
+	"context"
+	"os"
+
+	"github.com/edgexfoundry/edgex-go/internal"
+	"github.com/edgexfoundry/edgex-go/internal/security/bootstrapper/config"
+	"github.com/edgexfoundry/edgex-go/internal/security/bootstrapper/container"
+
+	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap"
+	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/flags"
+	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/interfaces"
+	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/startup"
+	"github.com/edgexfoundry/go-mod-bootstrap/di"
+
+	"github.com/gorilla/mux"
+)
+
+const (
+	securityBootstrapperServiceKey = "edgex-security-bootstrapper"
+)
+
+func Main(ctx context.Context, cancel context.CancelFunc, _ *mux.Router, _ chan<- bool) {
+	// service key for this bootstrapper service
+	startupTimer := startup.NewStartUpTimer(securityBootstrapperServiceKey)
+
+	var initNeeded bool
+
+	f := flags.NewWithUsage(
+		"    --init=true/false Indicates if bootstrapper should be initialized again",
+	)
+
+	if len(os.Args) < 2 {
+		f.Help()
+	}
+
+	f.FlagSet.BoolVar(&initNeeded, "init", false, "")
+	f.Parse(os.Args[1:])
+
+	configuration := &config.ConfigurationStruct{}
+	dic := di.NewContainer(di.ServiceConstructorMap{
+		container.ConfigurationName: func(get di.Get) interface{} {
+			return configuration
+		},
+	})
+
+	serviceHandler := NewBootstrap(initNeeded)
+
+	bootstrap.Run(
+		ctx,
+		cancel,
+		f,
+		securityBootstrapperServiceKey,
+		internal.ConfigStemSecurity+internal.ConfigMajorVersion,
+		configuration,
+		startupTimer,
+		dic,
+		[]interfaces.BootstrapHandler{
+			serviceHandler.BootstrapHandler,
+		},
+	)
+}

--- a/internal/security/bootstrapper/tcp_client.go
+++ b/internal/security/bootstrapper/tcp_client.go
@@ -1,0 +1,59 @@
+/*******************************************************************************
+ * Copyright 2020 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ *******************************************************************************/
+
+package bootstrapper
+
+import (
+	"bufio"
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
+)
+
+// DialTcp will instantiate a new TCP dialer trying to connect to the TCP server specified by host and port
+func DialTcp(host string, port int, lc logger.LoggingClient) {
+	tcpHost := strings.TrimSpace(host)
+	if len(tcpHost) == 0 || port == 0 {
+		// log and ignore those
+		lc.Info(fmt.Sprintf("Skipping: no TCP server specified, host=%s, port=%d", host, port))
+		return
+	}
+
+	lc.Info(fmt.Sprintf("Trying to connecting to TCP server %s on port %d", tcpHost, port))
+
+	tcpServerAddr := net.JoinHostPort(host, strconv.Itoa(port))
+
+	for { // keep trying until server connects
+		c, err := net.Dial("tcp", tcpServerAddr)
+		if err != nil {
+			lc.Debug(fmt.Sprintf("TCP server %s is not available yet, retry in 1 second", tcpServerAddr))
+			time.Sleep(time.Second)
+			continue
+		}
+		defer func() {
+			_ = c.Close()
+		}()
+
+		// connected: read the 1st line if anything
+		message, _ := bufio.NewReader(c).ReadString('\n')
+		lc.Debug(fmt.Sprintf("message from server: %s", message))
+		lc.Info(fmt.Sprintf("Connected with TCP server %s ", tcpServerAddr))
+		break
+	}
+}

--- a/internal/security/bootstrapper/tcp_listener.go
+++ b/internal/security/bootstrapper/tcp_listener.go
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Copyright 2020 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ *******************************************************************************/
+
+package bootstrapper
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"time"
+
+	"github.com/edgexfoundry/edgex-go/internal/security/secrets/contract"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
+)
+
+// StartListener will instantiate a new listener that signals process is done
+func StartListener(port int, lc logger.LoggingClient) {
+	lc.Info(fmt.Sprintf("Starting listener on port %d to signal the process is done...\n", port))
+
+	doneSrv := fmt.Sprintf(":%d", port)
+
+	listener, err := net.Listen("tcp", doneSrv)
+	checkError(err)
+
+	for {
+		conn, err := listener.Accept()
+		if err != nil {
+			lc.Error(fmt.Sprintf("found error %v when accepting connection!\n", err))
+			time.Sleep(2 * time.Second)
+			continue
+		}
+
+		go func() {
+			// raise the semaphore on port
+			daytime := time.Now().String()
+			_, _ = conn.Write([]byte(daytime)) // don't care about return value
+			_ = conn.Close()
+			// intended process listener is done
+			lc.Info(fmt.Sprintf("listener on port %d is done", port))
+		}()
+	}
+}
+
+func checkError(err error) {
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Fatal error: %s\n", err.Error())
+		os.Exit(contract.StatusCodeExitWithError)
+	}
+}


### PR DESCRIPTION
The scurity container bootstrapping initiates with security-bootstrapper service, in which it bootstraps
the pre-seeded secrets and db credentials.
The `security-bootstrapper` starts with seeding the `wait_install.sh` shell script (contains the `dockerize` utility)
to be available for other containers that needs to wait for the intended done-listener is issued and connected.
The other containers in the security bootstrapping process currently are:
 - Vault bootstrapping
 - Consul bootstrapping
 - Kong bootstrapping
 - Database like Redis bootstrapping

The `dockerize` utility is used on those above containers to wait for that `security-bootstrapper`
TCP  listener done signal and then those container can proceed to start up.

Still WIP...

Signed-off-by: Jim Wang <yutsung.jim.wang@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/master/.github/Contributing.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number: 


## What is the new behavior?
New security bootstrapping installer


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [X ] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [X ] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?

1. git clone this PR code. and run `make docker_security_bootstrapper` to create the docker image
1. cd to `./cmd/security-bootstrapper/testdata/` directory
1. run `./run_test.sh` shell script to observe the security-bootstrapping actions
1. you should see no error on the console

Sample console output:

```
jim@jim-NUC7i5DNHE:~/go/src/github.com/edgexfoundry/edgex-go/cmd/security-bootstrapper/testdata$ ./run_test.sh 
e45b148a8692c03d1d91f7ab1361d9d97d8a0cdadcd0218790b0bddaf5611477
6c0a681ab31843789d0cdad5b634623819980daf4daf7cb58ff78d359bbdd8ab
e6f02ef5958ff0ef4a3571272410f0608e0a5df03143768ab434eedb6aaf5567
Installing wait_install script
Copy dockerize executable
TBD: Boostrapping edgex-vault...
TBD: Boostrapping edgex-consul...
TBD: Boostrapping edgex-kong...
Script for waiting scurity install bootstrapping done on the listener
the current directory is /
Executing dockerize on vault server with waiting on tcp:54321
2020/11/24 22:13:26 Waiting for: tcp://edgex-security-installer:54321
2020/11/24 22:13:26 Problem with dial: dial tcp 172.31.0.2:54321: connect: connection refused. Sleeping 1s
2020/11/24 22:13:27 Problem with dial: dial tcp 172.31.0.2:54321: connect: connection refused. Sleeping 1s
2020/11/24 22:13:28 Problem with dial: dial tcp 172.31.0.2:54321: connect: connection refused. Sleeping 1s
2020/11/24 22:13:29 Problem with dial: dial tcp 172.31.0.2:54321: connect: connection refused. Sleeping 1s
2020/11/24 22:13:30 Problem with dial: dial tcp 172.31.0.2:54321: connect: connection refused. Sleeping 1s
2020/11/24 22:13:31 Problem with dial: dial tcp 172.31.0.2:54321: connect: connection refused. Sleeping 1s
2020/11/24 22:13:32 Problem with dial: dial tcp 172.31.0.2:54321: connect: connection refused. Sleeping 1s
2020/11/24 22:13:33 Problem with dial: dial tcp 172.31.0.2:54321: connect: connection refused. Sleeping 1s
2020/11/24 22:13:34 Problem with dial: dial tcp 172.31.0.2:54321: connect: connection refused. Sleeping 1s
2020/11/24 22:13:35 Problem with dial: dial tcp 172.31.0.2:54321: connect: connection refused. Sleeping 1s
2020/11/24 22:13:36 Problem with dial: dial tcp 172.31.0.2:54321: connect: connection refused. Sleeping 1s
2020/11/24 22:13:37 Problem with dial: dial tcp 172.31.0.2:54321: connect: connection refused. Sleeping 1s
2020/11/24 22:13:38 Problem with dial: dial tcp 172.31.0.2:54321: connect: connection refused. Sleeping 1s
2020/11/24 22:13:39 Problem with dial: dial tcp 172.31.0.2:54321: connect: connection refused. Sleeping 1s
2020/11/24 22:13:40 Problem with dial: dial tcp 172.31.0.2:54321: connect: connection refused. Sleeping 1s
2020/11/24 22:13:41 Connected to tcp://edgex-security-installer:54321
Starting edgex-vault...
==> Vault server configuration:

                     Cgo: disabled
              Go Version: go1.14.7
               Log Level: info
                   Mlock: supported: true, enabled: true
           Recovery Mode: false
                 Storage: file
                 Version: Vault v1.5.3
             Version Sha: 9fcd81405feb320390b9d71e15a691c3bc1daeef

==> Vault server started! Log data will stream in below:

2020-11-24T22:13:42.228Z [INFO]  proxy environment: http_proxy= https_proxy= no_proxy=
2020-11-24T22:13:42.228Z [WARN]  no `api_addr` value specified in config or in VAULT_API_ADDR; falling back to detection if possible, but this value should be manually set
e6f02ef5958f
6c0a681ab318
test-bootstrapper-net
```
## Other information